### PR TITLE
prevent metering agent from updating nat table

### DIFF
--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -71,6 +71,7 @@ class RouterWithMetering(object):
         self.router = router
         self.ns_name = NS_PREFIX + self.id if conf.use_namespaces else None
         self.iptables_manager = iptables_manager.IptablesManager(
+            state_less=True,
             namespace=self.ns_name,
             binary_name=WRAP_NAME,
             use_ipv6=ipv6_utils.is_enabled())


### PR DESCRIPTION
metering agent update nat table will corrupt rules in POSTROUTING chain. We have fix this in vizio/juno. porting to Kraken.
