### PR TITLE
Meterfix for iptables rules auto recovery

### DIFF
--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -56,7 +56,10 @@ class IptablesManagerTransaction(object):
     def __exit__(self, type, value, traceback):
         transaction = self.__transactions.get(self.im)
         if transaction == 1:
-            self.im.apply()
+            try:
+                self.im.apply()
+            except:
+                pass
             del self.__transactions[self.im]
         else:
             transaction -= 1
@@ -146,6 +149,12 @@ class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
     def _process_metering_label_rule_add(self, rm, rule, ext_dev,
                                          label_chain, rules_chain):
         im = rm.iptables_manager
+        try:
+            im.ipv4['filter'].add_chain(label_chain, wrap=False)
+            im.ipv4['filter'].add_rule(label_chain, '', wrap=False)
+            im.ipv4['filter'].add_chain(rules_chain, wrap=False)
+        except:
+            pass
         self._add_rule_to_chain(ext_dev, rule, im, label_chain, rules_chain)
 
     def _process_metering_label_rule_delete(self, rm, rule, ext_dev,

--- a/neutron/services/metering/drivers/iptables/iptables_driver.py
+++ b/neutron/services/metering/drivers/iptables/iptables_driver.py
@@ -374,7 +374,8 @@ class IptablesMeteringDriver(abstract_driver.MeteringAbstractDriver):
                 except RuntimeError:
                     LOG.warn(_LW('Failed to get traffic counters, '
                                       'router: %s'), router)
-                    routers_to_reconfigure.append(router['id'])
+                    if router['id'] not in routers_to_reconfigure:
+                        routers_to_reconfigure.append(router['id'])
                     continue
 
                 if not chain_acc:


### PR DESCRIPTION
Sometimes the iptables apply failed, the issue is reported in community launchpad and we found this in our setups too.
This fix is to auto recovery the iptables rules in router namepsace which is installed by metering-agent when apply failed.

We made the changes in kraken11 and it works well.
