### PR TITLE
Cherry pick community stable/mitaka fixes for L3/OVS agents

### DIFF
--- a/neutron/agent/l3/agent.py
+++ b/neutron/agent/l3/agent.py
@@ -64,6 +64,11 @@ NS_PREFIX = namespaces.NS_PREFIX
 INTERNAL_DEV_PREFIX = namespaces.INTERNAL_DEV_PREFIX
 EXTERNAL_DEV_PREFIX = namespaces.EXTERNAL_DEV_PREFIX
 
+# Number of routers to fetch from server at a time on resync.
+# Needed to reduce load on server side and to speed up resync on agent side.
+SYNC_ROUTERS_MAX_CHUNK_SIZE = 256
+SYNC_ROUTERS_MIN_CHUNK_SIZE = 32
+
 
 class L3PluginApi(object):
     """Agent side of the l3 agent RPC API.
@@ -82,6 +87,8 @@ class L3PluginApi(object):
         1.6 - Added process_prefix_update
         1.7 - DVR support: new L3 plugin methods added.
               - delete_agent_gateway_port
+        1.8 - Added address scope information
+        1.9 - Added get_router_ids
     """
 
     def __init__(self, topic, host):
@@ -94,6 +101,11 @@ class L3PluginApi(object):
         cctxt = self.client.prepare()
         return cctxt.call(context, 'sync_routers', host=self.host,
                           router_ids=router_ids)
+
+    def get_router_ids(self, context):
+        """Make a remote process call to retrieve scheduled routers ids."""
+        cctxt = self.client.prepare(version='1.9')
+        return cctxt.call(context, 'get_router_ids', host=self.host)
 
     def get_external_network_id(self, context):
         """Make a remote process call to retrieve the external network id.
@@ -187,6 +199,7 @@ class L3NATAgent(firewall_l3_agent.FWaaSL3AgentRpcCallback,
         self.context = n_context.get_admin_context_without_session()
         self.plugin_rpc = L3PluginApi(topics.L3PLUGIN, host)
         self.fullsync = True
+        self.sync_routers_chunk_size = SYNC_ROUTERS_MAX_CHUNK_SIZE
 
         # Get the list of service plugins from Neutron Server
         # This is the first place where we contact neutron-server on startup
@@ -553,46 +566,68 @@ class L3NATAgent(firewall_l3_agent.FWaaSL3AgentRpcCallback,
 
     def fetch_and_sync_all_routers(self, context, ns_manager):
         prev_router_ids = set(self.router_info)
+        curr_router_ids = set()
         timestamp = timeutils.utcnow()
 
         try:
-            if self.conf.use_namespaces:
-                routers = self.plugin_rpc.get_routers(context)
+            router_ids = ([self.conf.router_id] if self.conf.router_id else
+                          self.plugin_rpc.get_router_ids(context))
+            # fetch routers by chunks to reduce the load on server and to
+            # start router processing earlier
+            for i in range(0, len(router_ids), self.sync_routers_chunk_size):
+                routers = self.plugin_rpc.get_routers(
+                    context, router_ids[i:i + self.sync_routers_chunk_size])
+                LOG.debug('Processing :%r', routers)
+                for r in routers:
+                    curr_router_ids.add(r['id'])
+                    ns_manager.keep_router(r['id'])
+                    if r.get('distributed'):
+                        # need to keep fip namespaces as well
+                        ext_net_id = (r['external_gateway_info'] or {}).get(
+                            'network_id')
+                        if ext_net_id:
+                            ns_manager.keep_ext_net(ext_net_id)
+                    update = queue.RouterUpdate(
+                        r['id'],
+                        queue.PRIORITY_SYNC_ROUTERS_TASK,
+                        router=r,
+                        timestamp=timestamp)
+                    self._queue.add(update)
+        except oslo_messaging.MessagingTimeout:
+            if self.sync_routers_chunk_size > SYNC_ROUTERS_MIN_CHUNK_SIZE:
+                self.sync_routers_chunk_size = max(
+                    self.sync_routers_chunk_size / 2,
+                    SYNC_ROUTERS_MIN_CHUNK_SIZE)
+                LOG.error(_LE('Server failed to return info for routers in '
+                              'required time, decreasing chunk size to: %s'),
+                          self.sync_routers_chunk_size)
             else:
-                routers = self.plugin_rpc.get_routers(context,
-                                                      [self.conf.router_id])
-
+                LOG.error(_LE('Server failed to return info for routers in '
+                              'required time even with min chunk size: %s. '
+                              'It might be under very high load or '
+                              'just inoperable'),
+                          self.sync_routers_chunk_size)
+            raise
         except oslo_messaging.MessagingException:
             LOG.exception(_LE("Failed synchronizing routers due to RPC error"))
             raise n_exc.AbortSyncRouters()
-        else:
-            LOG.debug('Processing :%r', routers)
-            for r in routers:
-                ns_manager.keep_router(r['id'])
-                if r.get('distributed'):
-                    # need to keep fip namespaces as well
-                    ext_net_id = (r['external_gateway_info'] or {}).get(
-                        'network_id')
-                    if ext_net_id:
-                        ns_manager.keep_ext_net(ext_net_id)
-                update = queue.RouterUpdate(r['id'],
-                                            queue.PRIORITY_SYNC_ROUTERS_TASK,
-                                            router=r,
-                                            timestamp=timestamp)
-                self._queue.add(update)
-            self.fullsync = False
-            LOG.debug("periodic_sync_routers_task successfully completed")
 
-            curr_router_ids = set([r['id'] for r in routers])
+        self.fullsync = False
+        LOG.debug("periodic_sync_routers_task successfully completed")
+        # adjust chunk size after successful sync
+        if self.sync_routers_chunk_size < SYNC_ROUTERS_MAX_CHUNK_SIZE:
+            self.sync_routers_chunk_size = min(
+                self.sync_routers_chunk_size + SYNC_ROUTERS_MIN_CHUNK_SIZE,
+                SYNC_ROUTERS_MAX_CHUNK_SIZE)
 
-            # Delete routers that have disappeared since the last sync
-            for router_id in prev_router_ids - curr_router_ids:
-                ns_manager.keep_router(router_id)
-                update = queue.RouterUpdate(router_id,
-                                            queue.PRIORITY_SYNC_ROUTERS_TASK,
-                                            timestamp=timestamp,
-                                            action=queue.DELETE_ROUTER)
-                self._queue.add(update)
+        # Delete routers that have disappeared since the last sync
+        for router_id in prev_router_ids - curr_router_ids:
+            ns_manager.keep_router(router_id)
+            update = queue.RouterUpdate(router_id,
+                                        queue.PRIORITY_SYNC_ROUTERS_TASK,
+                                        timestamp=timestamp,
+                                        action=queue.DELETE_ROUTER)
+            self._queue.add(update)
 
     def after_start(self):
         # Note: the FWaaS' vArmourL3NATAgent is a subclass of L3NATAgent. It

--- a/neutron/agent/linux/polling.py
+++ b/neutron/agent/linux/polling.py
@@ -15,10 +15,14 @@
 import contextlib
 
 import eventlet
+from oslo_log import log as logging
 
 from neutron.agent.common import base_polling
+from neutron.agent.linux import async_process
 from neutron.agent.linux import ovsdb_monitor
 from neutron.plugins.ml2.drivers.openvswitch.agent.common import constants
+
+LOG = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -53,7 +57,10 @@ class InterfacePollingMinimizer(base_polling.BasePollingManager):
         self._monitor.start()
 
     def stop(self):
-        self._monitor.stop()
+        try:
+            self._monitor.stop()
+        except async_process.AsyncProcessException:
+            LOG.debug("InterfacePollingMinimizer was not running when stopped")
 
     def _is_polling_required(self):
         # Maximize the chances of update detection having a chance to

--- a/neutron/api/rpc/handlers/l3_rpc.py
+++ b/neutron/api/rpc/handlers/l3_rpc.py
@@ -46,7 +46,9 @@ class L3RpcCallback(object):
     # 1.5 Added update_ha_routers_states
     # 1.6 Added process_prefix_update to support IPv6 Prefix Delegation
     # 1.7 Added method delete_agent_gateway_port for DVR Routers
-    target = oslo_messaging.Target(version='1.7')
+    # 1.8 Added address scope information
+    # 1.9 Added get_router_ids
+    target = oslo_messaging.Target(version='1.9')
 
     @property
     def plugin(self):
@@ -60,6 +62,10 @@ class L3RpcCallback(object):
             self._l3plugin = manager.NeutronManager.get_service_plugins()[
                 plugin_constants.L3_ROUTER_NAT]
         return self._l3plugin
+
+    def get_router_ids(self, context, host):
+        """Returns IDs of routers scheduled to l3 agent on <host>"""
+        return self.l3plugin.list_router_ids_on_host(context, host)
 
     @db_api.retry_db_errors
     def sync_routers(self, context, **kwargs):

--- a/neutron/db/agents_db.py
+++ b/neutron/db/agents_db.py
@@ -29,6 +29,7 @@ from neutron.callbacks import events
 from neutron.callbacks import registry
 from neutron.callbacks import resources
 from neutron.common import constants
+from neutron.db import api as db_api
 from neutron.db import model_base
 from neutron.db import models_v2
 from neutron.extensions import agent as ext_agent
@@ -300,6 +301,7 @@ class AgentExtRpcCallback(object):
         super(AgentExtRpcCallback, self).__init__()
         self.plugin = plugin
 
+    @db_api.retry_db_errors
     def report_state(self, context, **kwargs):
         """Report state from agent to server.
 

--- a/neutron/db/l3_agentschedulers_db.py
+++ b/neutron/db/l3_agentschedulers_db.py
@@ -376,8 +376,7 @@ class L3AgentSchedulerDbMixin(l3agentscheduler.L3AgentSchedulerPluginBase,
 
         return self.get_sync_data(context, router_ids=router_ids, active=True)
 
-    def list_active_sync_routers_on_active_l3_agent(
-            self, context, host, router_ids):
+    def list_router_ids_on_host(self, context, host, router_ids=None):
         agent = self._get_agent_by_type_and_host(
             context, constants.AGENT_TYPE_L3, host)
         if not agentschedulers_db.services_available(agent.admin_state_up):
@@ -389,8 +388,15 @@ class L3AgentSchedulerDbMixin(l3agentscheduler.L3AgentSchedulerPluginBase,
         if router_ids:
             query = query.filter(
                 RouterL3AgentBinding.router_id.in_(router_ids))
-        router_ids = [item[0] for item in query]
+
+        return [item[0] for item in query]
+
+    def list_active_sync_routers_on_active_l3_agent(
+            self, context, host, router_ids):
+        router_ids = self.list_router_ids_on_host(context, host, router_ids)
         if router_ids:
+            agent = self._get_agent_by_type_and_host(
+                context, constants.AGENT_TYPE_L3, host)
             return self._get_active_l3_agent_routers_sync_data(context, host,
                                                                agent,
                                                                router_ids)

--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -34,7 +34,6 @@ from neutron.agent.common import ovs_lib
 from neutron.agent.common import polling
 from neutron.agent.common import utils
 from neutron.agent.l2.extensions import manager as ext_manager
-from neutron.agent.linux import async_process
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import polling as linux_polling
 from neutron.agent import rpc as agent_rpc
@@ -1907,12 +1906,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 # no action and by InterfacePollingMinimizer as start/stop
                 if isinstance(
                     polling_manager, linux_polling.InterfacePollingMinimizer):
-                    # There's a possible race here, when ovsdb-server is
-                    # restarted ovsdb monitor will also be restarted
-                    try:
-                        polling_manager.stop()
-                    except async_process.AsyncProcessException:
-                        LOG.debug("OVSDB monitor was not running")
+                    polling_manager.stop()
                     polling_manager.start()
             elif ovs_status == constants.OVS_DEAD:
                 # Agent doesn't apply any operations when ovs is dead, to

--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -813,7 +813,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 LOG.error(_LE("Expected port %s not found"), port.vif_id)
             else:
                 LOG.debug("Unable to get config for port %s", port.vif_id)
-            return
+            return False
 
         vlan_mapping = {'net_uuid': net_uuid,
                         'network_type': network_type,
@@ -823,6 +823,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         port_other_config.update(vlan_mapping)
         self.int_br.set_db_attribute("Port", port.port_name, "other_config",
                                      port_other_config)
+        return True
 
     def _add_port_tag_info(self, need_binding_ports):
         port_names = [p['vif_port'].port_name for p in need_binding_ports]
@@ -1324,9 +1325,10 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                          "and might not be able to transmit"), vif_port.vif_id)
         if vif_port:
             if admin_state_up:
-                self.port_bound(vif_port, network_id, network_type,
-                                physical_network, segmentation_id,
-                                fixed_ips, device_owner, ovs_restarted)
+                port_needs_binding = self.port_bound(
+                    vif_port, network_id, network_type,
+                    physical_network, segmentation_id,
+                    fixed_ips, device_owner, ovs_restarted)
             else:
                 LOG.info(_LI("VIF port: %s admin state up disabled, "
                              "putting on the dead VLAN"), vif_port.vif_id)

--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -41,7 +41,6 @@ from neutron.agent import securitygroups_rpc as sg_rpc
 from neutron.api.rpc.handlers import dvr_rpc
 from neutron.common import config
 from neutron.common import constants as n_const
-from neutron.common import exceptions
 from neutron.common import ipv6_utils as ipv6
 from neutron.common import topics
 from neutron.common import utils as n_utils
@@ -68,10 +67,6 @@ UINT64_BITMASK = (1 << 64) - 1
 
 class _mac_mydialect(netaddr.mac_unix):
     word_fmt = '%.2x'
-
-
-class DeviceListRetrievalError(exceptions.NeutronException):
-    message = _("Unable to retrieve port details for devices: %(devices)s ")
 
 
 class LocalVLANMapping(object):
@@ -848,6 +843,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
     def _bind_devices(self, need_binding_ports):
         devices_up = []
         devices_down = []
+        failed_devices = []
         port_names = [p['vif_port'].port_name for p in need_binding_ports]
         port_info = self.int_br.get_ports_attributes(
             "Port", columns=["name", "tag"], ports=port_names, if_exists=True)
@@ -886,22 +882,19 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             else:
                 LOG.debug("Setting status for %s to DOWN", device)
                 devices_down.append(device)
-        failed_devices = []
         if devices_up or devices_down:
             devices_set = self.plugin_rpc.update_device_list(
                 self.context, devices_up, devices_down, self.agent_id,
                 self.conf.host)
             failed_devices = (devices_set.get('failed_devices_up') +
                 devices_set.get('failed_devices_down'))
-        if failed_devices:
-            LOG.error(_LE("Configuration for devices %s failed!"),
-                      failed_devices)
-            #TODO(rossella_s) handle better the resync in next patches,
-            # this is just to preserve the current behavior
-            raise DeviceListRetrievalError(devices=failed_devices)
+            if failed_devices:
+                LOG.error(_LE("Configuration for devices %s failed!"),
+                          failed_devices)
         LOG.info(_LI("Configuration for devices up %(up)s and devices "
                      "down %(down)s completed."),
                  {'up': devices_up, 'down': devices_down})
+        return set(failed_devices)
 
     @staticmethod
     def setup_arp_spoofing_protection(bridge, vif, port_details):
@@ -1267,8 +1260,25 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         port_info['removed'] = registered_ports - cur_ports
         return port_info
 
+    def _update_port_info_failed_devices_stats(self, port_info,
+                                               failed_devices):
+        # remove failed devices that don't need to be retried
+        failed_devices['added'] -= port_info['removed']
+        failed_devices['removed'] -= port_info['added']
+
+        # Disregard devices that were never noticed by the agent
+        port_info['removed'] &= port_info['current']
+        # retry failed devices
+        port_info['added'] |= failed_devices['added']
+        LOG.debug("retrying failed devices %s", failed_devices['added'])
+        port_info['removed'] |= failed_devices['removed']
+        # Update current ports
+        port_info['current'] |= port_info['added']
+        port_info['current'] -= port_info['removed']
+
     def process_ports_events(self, events, registered_ports, ancillary_ports,
-                             old_ports_not_ready, updated_ports=None):
+                             old_ports_not_ready, failed_devices,
+                             failed_ancillary_devices, updated_ports=None):
         port_info = {}
         port_info['added'] = set()
         port_info['removed'] = set()
@@ -1278,8 +1288,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         ancillary_port_info['added'] = set()
         ancillary_port_info['removed'] = set()
         ancillary_port_info['current'] = ancillary_ports
-        ports_not_ready_yet = set()
 
+        ports_not_ready_yet = set()
         # if a port was added and then removed or viceversa since the agent
         # can't know the order of the operations, check the status of the port
         # to determine if the port was added or deleted
@@ -1339,18 +1349,13 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             _process_port(port, port_info['removed'],
                           ancillary_port_info['removed'])
 
+        self._update_port_info_failed_devices_stats(port_info, failed_devices)
+        self._update_port_info_failed_devices_stats(ancillary_port_info,
+                                failed_ancillary_devices)
+
         if updated_ports is None:
             updated_ports = set()
         updated_ports.update(self.check_changed_vlans())
-
-        # Disregard devices that were never noticed by the agent
-        port_info['removed'] &= port_info['current']
-        port_info['current'] |= port_info['added']
-        port_info['current'] -= port_info['removed']
-
-        ancillary_port_info['removed'] &= ancillary_port_info['current']
-        ancillary_port_info['current'] |= ancillary_port_info['added']
-        ancillary_port_info['current'] -= ancillary_port_info['removed']
 
         if updated_ports:
             # Some updated ports might have been removed in the
@@ -1499,10 +1504,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 devices,
                 self.agent_id,
                 self.conf.host))
-        if devices_details_list.get('failed_devices'):
-            #TODO(rossella_s) handle better the resync in next patches,
-            # this is just to preserve the current behavior
-            raise DeviceListRetrievalError(devices=devices)
+        failed_devices = set(devices_details_list.get('failed_devices'))
 
         devices = devices_details_list.get('devices')
         vif_by_id = self.int_br.get_vifs_by_ids(
@@ -1545,7 +1547,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 LOG.warn(_LW("Device %s not defined on plugin"), device)
                 if (port and port.ofport != -1):
                     self.port_dead(port)
-        return skipped_devices, need_binding_devices, security_disabled_devices
+        return (skipped_devices, need_binding_devices,
+                security_disabled_devices, failed_devices)
 
     def _update_port_network(self, port_id, network_id):
         self._clean_network_ports(port_id)
@@ -1558,13 +1561,9 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 devices,
                 self.agent_id,
                 self.conf.host))
-        if devices_details_list.get('failed_devices'):
-            #TODO(rossella_s) handle better the resync in next patches,
-            # this is just to preserve the current behavior
-            raise DeviceListRetrievalError(devices=devices)
+        failed_devices = set(devices_details_list.get('failed_devices'))
         devices_added = [
             d['device'] for d in devices_details_list.get('devices')]
-        LOG.info(_LI("Ancillary Ports %s added"), devices_added)
 
         # update plugin about port status
         devices_set_up = (
@@ -1573,13 +1572,13 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                                                [],
                                                self.agent_id,
                                                self.conf.host))
-        if devices_set_up.get('failed_devices_up'):
-            #TODO(rossella_s) handle better the resync in next patches,
-            # this is just to preserve the current behavior
-            raise DeviceListRetrievalError()
+        failed_devices |= set(devices_set_up.get('failed_devices_up'))
+        LOG.info(_LI("Ancillary Ports %(added)s added, failed devices "
+                     "%(failed)s"), {'added': devices,
+                                     'failed': failed_devices})
+        return failed_devices
 
     def treat_devices_removed(self, devices):
-        resync = False
         self.sg_agent.remove_devices_filter(devices)
         LOG.info(_LI("Ports %s removed"), devices)
         devices_down = self.plugin_rpc.update_device_list(self.context,
@@ -1587,37 +1586,33 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                                                           devices,
                                                           self.agent_id,
                                                           self.conf.host)
-        failed_devices = devices_down.get('failed_devices_down')
-        if failed_devices:
-            LOG.debug("Port removal failed for %(devices)s ", failed_devices)
-            resync = True
+        failed_devices = set(devices_down.get('failed_devices_down'))
+        LOG.debug("Port removal failed for %s", failed_devices)
         for device in devices:
             self.port_unbound(device)
-        return resync
+        return failed_devices
 
     def treat_ancillary_devices_removed(self, devices):
-        resync = False
         LOG.info(_LI("Ancillary ports %s removed"), devices)
         devices_down = self.plugin_rpc.update_device_list(self.context,
                                                           [],
                                                           devices,
                                                           self.agent_id,
                                                           self.conf.host)
-        failed_devices = devices_down.get('failed_devices_down')
+        LOG.info(_LI("Devices down  %s "), devices_down)
+        failed_devices = set(devices_down.get('failed_devices_down'))
         if failed_devices:
-            LOG.debug("Port removal failed for %(devices)s ", failed_devices)
-            resync = True
+            LOG.debug("Port removal failed for %(devices)s", failed_devices)
         for detail in devices_down.get('devices_down'):
             if detail['exists']:
                 LOG.info(_LI("Port %s updated."), detail['device'])
                 # Nothing to do regarding local networking
             else:
                 LOG.debug("Device %s not defined on plugin", detail['device'])
-        return resync
+        return failed_devices
 
     def process_network_ports(self, port_info, ovs_restarted):
-        resync_a = False
-        resync_b = False
+        failed_devices = {'added': set(), 'removed': set()}
         # TODO(salv-orlando): consider a solution for ensuring notifications
         # are processed exactly in the same order in which they were
         # received. This is tricky because there are two notification
@@ -1635,31 +1630,23 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         security_disabled_ports = []
         if devices_added_updated:
             start = time.time()
-            try:
-                (skipped_devices, need_binding_devices,
-                    security_disabled_ports) = (
-                    self.treat_devices_added_or_updated(
-                        devices_added_updated, ovs_restarted))
-                LOG.debug("process_network_ports - iteration:%(iter_num)d - "
-                          "treat_devices_added_or_updated completed. "
-                          "Skipped %(num_skipped)d devices of "
-                          "%(num_current)d devices currently available. "
-                          "Time elapsed: %(elapsed).3f",
-                          {'iter_num': self.iter_num,
-                           'num_skipped': len(skipped_devices),
-                           'num_current': len(port_info['current']),
-                           'elapsed': time.time() - start})
-                # Update the list of current ports storing only those which
-                # have been actually processed.
-                port_info['current'] = (port_info['current'] -
-                                        set(skipped_devices))
-            except DeviceListRetrievalError:
-                # Need to resync as there was an error with server
-                # communication.
-                LOG.exception(_LE("process_network_ports - iteration:%d - "
-                                  "failure while retrieving port details "
-                                  "from server"), self.iter_num)
-                resync_a = True
+            (skipped_devices, need_binding_devices,
+            security_disabled_ports, failed_devices['added']) = (
+                self.treat_devices_added_or_updated(
+                    devices_added_updated, ovs_restarted))
+            LOG.debug("process_network_ports - iteration:%(iter_num)d - "
+                      "treat_devices_added_or_updated completed. "
+                      "Skipped %(num_skipped)d devices of "
+                      "%(num_current)d devices currently available. "
+                      "Time elapsed: %(elapsed).3f",
+                      {'iter_num': self.iter_num,
+                       'num_skipped': len(skipped_devices),
+                       'num_current': len(port_info['current']),
+                       'elapsed': time.time() - start})
+            # Update the list of current ports storing only those which
+            # have been actually processed.
+            port_info['current'] = (port_info['current'] -
+                                    set(skipped_devices))
 
         # TODO(salv-orlando): Optimize avoiding applying filters
         # unnecessarily, (eg: when there are no IP address changes)
@@ -1669,49 +1656,43 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             added_ports -= set(security_disabled_ports)
         self.sg_agent.setup_port_filters(added_ports,
                                          port_info.get('updated', set()))
-        self._bind_devices(need_binding_devices)
+        failed_devices['added'] |= self._bind_devices(need_binding_devices)
 
         if 'removed' in port_info and port_info['removed']:
             start = time.time()
-            resync_b = self.treat_devices_removed(port_info['removed'])
+            failed_devices['removed'] |= self.treat_devices_removed(
+                port_info['removed'])
             LOG.debug("process_network_ports - iteration:%(iter_num)d - "
                       "treat_devices_removed completed in %(elapsed).3f",
                       {'iter_num': self.iter_num,
                        'elapsed': time.time() - start})
-        # If one of the above operations fails => resync with plugin
-        return (resync_a | resync_b)
+        return failed_devices
 
     def process_ancillary_network_ports(self, port_info):
-        resync_a = False
-        resync_b = False
+        failed_devices = {'added': set(), 'removed': set()}
         if 'added' in port_info and port_info['added']:
             start = time.time()
-            try:
-                self.treat_ancillary_devices_added(port_info['added'])
-                LOG.debug("process_ancillary_network_ports - iteration: "
-                          "%(iter_num)d - treat_ancillary_devices_added "
-                          "completed in %(elapsed).3f",
-                          {'iter_num': self.iter_num,
-                           'elapsed': time.time() - start})
-            except DeviceListRetrievalError:
-                # Need to resync as there was an error with server
-                # communication.
-                LOG.exception(_LE("process_ancillary_network_ports - "
-                                  "iteration:%d - failure while retrieving "
-                                  "port details from server"), self.iter_num)
-                resync_a = True
+            failed_added = self.treat_ancillary_devices_added(
+                port_info['added'])
+            LOG.debug("process_ancillary_network_ports - iteration: "
+                      "%(iter_num)d - treat_ancillary_devices_added "
+                      "completed in %(elapsed).3f",
+                      {'iter_num': self.iter_num,
+                       'elapsed': time.time() - start})
+            failed_devices['added'] = failed_added
+
         if 'removed' in port_info and port_info['removed']:
             start = time.time()
-            resync_b = self.treat_ancillary_devices_removed(
+            failed_removed = self.treat_ancillary_devices_removed(
                 port_info['removed'])
+            failed_devices['removed'] = failed_removed
+
             LOG.debug("process_ancillary_network_ports - iteration: "
                       "%(iter_num)d - treat_ancillary_devices_removed "
                       "completed in %(elapsed).3f",
                       {'iter_num': self.iter_num,
                        'elapsed': time.time() - start})
-
-        # If one of the above operations fails => resync with plugin
-        return (resync_a | resync_b)
+        return failed_devices
 
     def get_ip_in_hex(self, ip_address):
         try:
@@ -1809,7 +1790,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
 
     def process_port_info(self, start, polling_manager, sync, ovs_restarted,
                        ports, ancillary_ports, updated_ports_copy,
-                       consecutive_resyncs, ports_not_ready_yet):
+                       consecutive_resyncs, ports_not_ready_yet,
+                       failed_devices, failed_ancillary_devices):
         # There are polling managers that don't have get_events, e.g.
         # AlwaysPoll used by windows implementations
         # REVISIT (rossella_s) This needs to be reworked to hide implementation
@@ -1829,6 +1811,10 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     consecutive_resyncs = 0
             else:
                 consecutive_resyncs = 0
+                # TODO(rossella_s): For implementations that use AlwaysPoll
+                # resync if a device failed. This can be improved in future
+                sync = (any(failed_devices.values()) or
+                    any(failed_ancillary_devices.values()))
 
             # NOTE(rossella_s) don't empty the queue of events
             # calling polling_manager.get_events() since
@@ -1855,6 +1841,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             port_info, ancillary_port_info, ports_not_ready_yet = (
                 self.process_ports_events(events, ports, ancillary_ports,
                                           ports_not_ready_yet,
+                                          failed_devices,
+                                          failed_ancillary_devices,
                                           updated_ports_copy))
         return (port_info, ancillary_port_info, consecutive_resyncs,
                 ports_not_ready_yet)
@@ -1873,6 +1861,9 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         consecutive_resyncs = 0
         need_clean_stale_flow = True
         ports_not_ready_yet = set()
+        failed_devices = {'added': set(), 'removed': set()}
+        failed_ancillary_devices = {'added': set(), 'removed': set()}
+
         while self._check_and_handle_signal():
             if self.fullsync:
                 LOG.info(_LI("rpc_loop doing a full sync."))
@@ -1924,8 +1915,11 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     LOG.exception(_LE("Error while synchronizing tunnels"))
                     tunnel_sync = True
             ovs_restarted |= (ovs_status == constants.OVS_RESTARTED)
+            devices_need_retry = (any(failed_devices.values()) or
+                any(failed_ancillary_devices.values()) or
+                ports_not_ready_yet)
             if (self._agent_has_updates(polling_manager) or sync
-                    or ports_not_ready_yet):
+                    or devices_need_retry):
                 try:
                     LOG.debug("Agent rpc_loop - iteration:%(iter_num)d - "
                               "starting polling. Elapsed:%(elapsed).3f",
@@ -1941,8 +1935,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                      ports_not_ready_yet) = (self.process_port_info(
                             start, polling_manager, sync, ovs_restarted,
                             ports, ancillary_ports, updated_ports_copy,
-                            consecutive_resyncs, ports_not_ready_yet)
-                    )
+                            consecutive_resyncs, ports_not_ready_yet,
+                            failed_devices, failed_ancillary_devices))
                     sync = False
                     self.process_deleted_ports(port_info)
                     ofport_changed_ports = self.update_stale_ofport_rules()
@@ -1961,10 +1955,9 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                         ovs_restarted):
                         LOG.debug("Starting to process devices in:%s",
                                   port_info)
-                        # If treat devices fails - must resync with plugin
-                        sync = self.process_network_ports(port_info,
-                                                          ovs_restarted)
-                        if not sync and need_clean_stale_flow:
+                        failed_devices = self.process_network_ports(
+                            port_info, ovs_restarted)
+                        if need_clean_stale_flow:
                             self.cleanup_stale_flows()
                             need_clean_stale_flow = False
                         LOG.debug("Agent rpc_loop - iteration:%(iter_num)d - "
@@ -1975,8 +1968,9 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     ports = port_info['current']
 
                     if self.ancillary_brs:
-                        sync |= self.process_ancillary_network_ports(
-                            ancillary_port_info)
+                        failed_ancillary_devices = (
+                            self.process_ancillary_network_ports(
+                                ancillary_port_info))
                         LOG.debug("Agent rpc_loop - iteration: "
                                   "%(iter_num)d - ancillary ports "
                                   "processed. Elapsed:%(elapsed).3f",
@@ -1987,9 +1981,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     polling_manager.polling_completed()
                     # Keep this flag in the last line of "try" block,
                     # so we can sure that no other Exception occurred.
-                    if not sync:
-                        ovs_restarted = False
-                        self._dispose_local_vlan_hints()
+                    ovs_restarted = False
+                    self._dispose_local_vlan_hints()
                 except Exception:
                     LOG.exception(_LE("Error while processing VIF ports"))
                     # Put the ports back in self.updated_port

--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -34,7 +34,9 @@ from neutron.agent.common import ovs_lib
 from neutron.agent.common import polling
 from neutron.agent.common import utils
 from neutron.agent.l2.extensions import manager as ext_manager
+from neutron.agent.linux import async_process
 from neutron.agent.linux import ip_lib
+from neutron.agent.linux import polling as linux_polling
 from neutron.agent import rpc as agent_rpc
 from neutron.agent import securitygroups_rpc as sg_rpc
 from neutron.api.rpc.handlers import dvr_rpc
@@ -183,7 +185,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         super(OVSNeutronAgent, self).__init__()
         self.conf = conf or cfg.CONF
 
-        self.fullsync = True
+        self.fullsync = False
         # init bridge classes with configured datapath type.
         self.br_int_cls, self.br_phys_cls, self.br_tun_cls = (
             functools.partial(bridge_classes[b],
@@ -1266,6 +1268,100 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         port_info['removed'] = registered_ports - cur_ports
         return port_info
 
+    def process_ports_events(self, events, registered_ports, ancillary_ports,
+                             old_ports_not_ready, updated_ports=None):
+        port_info = {}
+        port_info['added'] = set()
+        port_info['removed'] = set()
+        port_info['current'] = registered_ports
+
+        ancillary_port_info = {}
+        ancillary_port_info['added'] = set()
+        ancillary_port_info['removed'] = set()
+        ancillary_port_info['current'] = ancillary_ports
+        ports_not_ready_yet = set()
+
+        # if a port was added and then removed or viceversa since the agent
+        # can't know the order of the operations, check the status of the port
+        # to determine if the port was added or deleted
+        ports_removed_and_added = [
+            p for p in events['added'] if p in events['removed']]
+        for p in ports_removed_and_added:
+            if ovs_lib.BaseOVS().port_exists(p['name']):
+                events['removed'].remove(p)
+            else:
+                events['added'].remove(p)
+
+        #TODO(rossella_s): scanning the ancillary bridge won't be needed
+        # anymore when https://review.openstack.org/#/c/203381 since the bridge
+        # id stored in external_ids will be used to identify the bridge the
+        # port belongs to
+        cur_ancillary_ports = set()
+        for bridge in self.ancillary_brs:
+            cur_ancillary_ports |= bridge.get_vif_port_set()
+        cur_ancillary_ports |= ancillary_port_info['current']
+
+        def _process_port(port, ports, ancillary_ports):
+            # check 'iface-id' is set otherwise is not a port
+            # the agent should care about
+            if 'attached-mac' in port.get('external_ids', []):
+                iface_id = self.int_br.portid_from_external_ids(
+                    port['external_ids'])
+                if iface_id:
+                    if port['ofport'] == ovs_lib.UNASSIGNED_OFPORT:
+                        LOG.debug("Port %s not ready yet on the bridge",
+                                  iface_id)
+                        ports_not_ready_yet.add(port['name'])
+                        return
+                    # check if port belongs to ancillary bridge
+                    if iface_id in cur_ancillary_ports:
+                        ancillary_ports.add(iface_id)
+                    else:
+                        ports.add(iface_id)
+        if old_ports_not_ready:
+            old_ports_not_ready_attrs = self.int_br.get_ports_attributes(
+                'Interface', columns=['name', 'external_ids', 'ofport'],
+                ports=old_ports_not_ready, if_exists=True)
+            now_ready_ports = set(
+                [p['name'] for p in old_ports_not_ready_attrs])
+            LOG.debug("Ports %s are now ready", now_ready_ports)
+            old_ports_not_ready_yet = old_ports_not_ready - now_ready_ports
+            removed_ports = set([p['name'] for p in events['removed']])
+            old_ports_not_ready_yet -= removed_ports
+            LOG.debug("Ports %s were not ready at last iteration and are not "
+                      "ready yet", old_ports_not_ready_yet)
+            ports_not_ready_yet |= old_ports_not_ready_yet
+            events['added'].extend(old_ports_not_ready_attrs)
+
+        for port in events['added']:
+            _process_port(port, port_info['added'],
+                          ancillary_port_info['added'])
+        for port in events['removed']:
+            _process_port(port, port_info['removed'],
+                          ancillary_port_info['removed'])
+
+        if updated_ports is None:
+            updated_ports = set()
+        updated_ports.update(self.check_changed_vlans())
+
+        # Disregard devices that were never noticed by the agent
+        port_info['removed'] &= port_info['current']
+        port_info['current'] |= port_info['added']
+        port_info['current'] -= port_info['removed']
+
+        ancillary_port_info['removed'] &= ancillary_port_info['current']
+        ancillary_port_info['current'] |= ancillary_port_info['added']
+        ancillary_port_info['current'] -= ancillary_port_info['removed']
+
+        if updated_ports:
+            # Some updated ports might have been removed in the
+            # meanwhile, and therefore should not be processed.
+            # In this case the updated port won't be found among
+            # current ports.
+            updated_ports &= port_info['current']
+            port_info['updated'] = updated_ports
+        return port_info, ancillary_port_info, ports_not_ready_yet
+
     def scan_ports(self, registered_ports, sync, updated_ports=None):
         cur_ports = self.int_br.get_vif_port_set()
         self.int_br_device_count = len(cur_ports)
@@ -1712,11 +1808,64 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             LOG.info(_LI("Cleaning stale %s flows"), bridge.br_name)
             bridge.cleanup_flows()
 
+    def process_port_info(self, start, polling_manager, sync, ovs_restarted,
+                       ports, ancillary_ports, updated_ports_copy,
+                       consecutive_resyncs, ports_not_ready_yet):
+        # There are polling managers that don't have get_events, e.g.
+        # AlwaysPoll used by windows implementations
+        # REVISIT (rossella_s) This needs to be reworked to hide implementation
+        # details regarding polling in BasePollingManager subclasses
+        if sync or not (hasattr(polling_manager, 'get_events')):
+            if sync:
+                LOG.info(_LI("Agent out of sync with plugin!"))
+                consecutive_resyncs = consecutive_resyncs + 1
+                if (consecutive_resyncs >=
+                        constants.MAX_DEVICE_RETRIES):
+                    LOG.warn(_LW(
+                        "Clearing cache of registered ports,"
+                        " retries to resync were > %s"),
+                             constants.MAX_DEVICE_RETRIES)
+                    ports.clear()
+                    ancillary_ports.clear()
+                    consecutive_resyncs = 0
+            else:
+                consecutive_resyncs = 0
+
+            # NOTE(rossella_s) don't empty the queue of events
+            # calling polling_manager.get_events() since
+            # the agent might miss some event (for example a port
+            # deletion)
+            reg_ports = (set() if ovs_restarted else ports)
+            port_info = self.scan_ports(reg_ports, sync,
+                                        updated_ports_copy)
+            # Treat ancillary devices if they exist
+            if self.ancillary_brs:
+                ancillary_port_info = self.scan_ancillary_ports(
+                    ancillary_ports, sync)
+                LOG.debug("Agent rpc_loop - iteration:%(iter_num)d"
+                          " - ancillary port info retrieved. "
+                          "Elapsed:%(elapsed).3f",
+                          {'iter_num': self.iter_num,
+                           'elapsed': time.time() - start})
+            else:
+                ancillary_port_info = {}
+
+        else:
+            consecutive_resyncs = 0
+            events = polling_manager.get_events()
+            port_info, ancillary_port_info, ports_not_ready_yet = (
+                self.process_ports_events(events, ports, ancillary_ports,
+                                          ports_not_ready_yet,
+                                          updated_ports_copy))
+        return (port_info, ancillary_port_info, consecutive_resyncs,
+                ports_not_ready_yet)
+
     def rpc_loop(self, polling_manager=None):
         if not polling_manager:
             polling_manager = polling.get_polling_manager(
                 minimize_polling=False)
-        sync = True
+
+        sync = False
         ports = set()
         updated_ports_copy = set()
         ancillary_ports = set()
@@ -1724,6 +1873,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         ovs_restarted = False
         consecutive_resyncs = 0
         need_clean_stale_flow = True
+        ports_not_ready_yet = set()
         while self._check_and_handle_signal():
             if self.fullsync:
                 LOG.info(_LI("rpc_loop doing a full sync."))
@@ -1734,20 +1884,6 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
             start = time.time()
             LOG.debug("Agent rpc_loop - iteration:%d started",
                       self.iter_num)
-            if sync:
-                LOG.info(_LI("Agent out of sync with plugin!"))
-                polling_manager.force_polling()
-                consecutive_resyncs = consecutive_resyncs + 1
-                if consecutive_resyncs >= constants.MAX_DEVICE_RETRIES:
-                    LOG.warn(_LW("Clearing cache of registered ports, retrials"
-                                 " to resync were > %s"),
-                             constants.MAX_DEVICE_RETRIES)
-                    ports.clear()
-                    ancillary_ports.clear()
-                    sync = False
-                    consecutive_resyncs = 0
-            else:
-                consecutive_resyncs = 0
             ovs_status = self.check_ovs_status()
             if ovs_status == constants.OVS_RESTARTED:
                 self.setup_integration_br()
@@ -1764,6 +1900,20 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                                                  self.patch_tun_ofport)
                     self.dvr_agent.reset_dvr_parameters()
                     self.dvr_agent.setup_dvr_flows()
+                # restart the polling manager so that it will signal as added
+                # all the current ports
+                # REVISIT (rossella_s) Define a method "reset" in
+                # BasePollingManager that will be implemented by AlwaysPoll as
+                # no action and by InterfacePollingMinimizer as start/stop
+                if isinstance(
+                    polling_manager, linux_polling.InterfacePollingMinimizer):
+                    # There's a possible race here, when ovsdb-server is
+                    # restarted ovsdb monitor will also be restarted
+                    try:
+                        polling_manager.stop()
+                    except async_process.AsyncProcessException:
+                        LOG.debug("OVSDB monitor was not running")
+                    polling_manager.start()
             elif ovs_status == constants.OVS_DEAD:
                 # Agent doesn't apply any operations when ovs is dead, to
                 # prevent unexpected failure or crash. Sleep and continue
@@ -1780,7 +1930,8 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     LOG.exception(_LE("Error while synchronizing tunnels"))
                     tunnel_sync = True
             ovs_restarted |= (ovs_status == constants.OVS_RESTARTED)
-            if self._agent_has_updates(polling_manager) or ovs_restarted:
+            if (self._agent_has_updates(polling_manager) or sync
+                    or ports_not_ready_yet):
                 try:
                     LOG.debug("Agent rpc_loop - iteration:%(iter_num)d - "
                               "starting polling. Elapsed:%(elapsed).3f",
@@ -1792,9 +1943,13 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                     # between these two statements, this will be thread-safe
                     updated_ports_copy = self.updated_ports
                     self.updated_ports = set()
-                    reg_ports = (set() if ovs_restarted else ports)
-                    port_info = self.scan_ports(reg_ports, sync,
-                                                updated_ports_copy)
+                    (port_info, ancillary_port_info, consecutive_resyncs,
+                     ports_not_ready_yet) = (self.process_port_info(
+                            start, polling_manager, sync, ovs_restarted,
+                            ports, ancillary_ports, updated_ports_copy,
+                            consecutive_resyncs, ports_not_ready_yet)
+                    )
+                    sync = False
                     self.process_deleted_ports(port_info)
                     ofport_changed_ports = self.update_stale_ofport_rules()
                     if ofport_changed_ports:
@@ -1805,16 +1960,6 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                               "Elapsed:%(elapsed).3f",
                               {'iter_num': self.iter_num,
                                'elapsed': time.time() - start})
-                    # Treat ancillary devices if they exist
-                    if self.ancillary_brs:
-                        ancillary_port_info = self.scan_ancillary_ports(
-                            ancillary_ports, sync)
-                        LOG.debug("Agent rpc_loop - iteration:%(iter_num)d - "
-                                  "ancillary port info retrieved. "
-                                  "Elapsed:%(elapsed).3f",
-                                  {'iter_num': self.iter_num,
-                                   'elapsed': time.time() - start})
-                    sync = False
                     # Secure and wire/unwire VIFs and update their status
                     # on Neutron server
                     if (self._port_info_has_changes(port_info) or

--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -1847,6 +1847,64 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         return (port_info, ancillary_port_info, consecutive_resyncs,
                 ports_not_ready_yet)
 
+    def _remove_devices_not_to_retry(self, failed_devices,
+                                     failed_ancillary_devices,
+                                     devices_not_to_retry,
+                                     ancillary_devices_not_to_retry):
+        """This method removes the devices that exceeded the number of retries
+           from failed_devices and failed_ancillary_devices
+
+        """
+        for event in ['added', 'removed']:
+            failed_devices[event] = (
+                failed_devices[event] - devices_not_to_retry[event])
+            failed_ancillary_devices[event] = (
+                failed_ancillary_devices[event] -
+                ancillary_devices_not_to_retry[event])
+
+    def _get_devices_not_to_retry(self, failed_devices,
+                                  failed_ancillary_devices,
+                                  failed_devices_retries_map):
+        """Return the devices not to retry and update the retries map"""
+        new_failed_devices_retries_map = {}
+        devices_not_to_retry = {}
+        ancillary_devices_not_to_retry = {}
+
+        def _increase_retries(devices_set):
+            devices_not_to_retry = set()
+            for dev in devices_set:
+                retries = failed_devices_retries_map.get(dev, 0)
+                if retries >= constants.MAX_DEVICE_RETRIES:
+                    devices_not_to_retry.add(dev)
+                    LOG.warning(_LW(
+                        "Device %(dev)s failed for %(times)s times and won't "
+                        "be retried anymore"), {
+                            'dev': dev, 'times': constants.MAX_DEVICE_RETRIES})
+                else:
+                    new_failed_devices_retries_map[dev] = retries + 1
+            return devices_not_to_retry
+
+        for event in ['added', 'removed']:
+            devices_not_to_retry[event] = _increase_retries(
+                failed_devices[event])
+            ancillary_devices_not_to_retry[event] = _increase_retries(
+                failed_ancillary_devices[event])
+
+        return (new_failed_devices_retries_map, devices_not_to_retry,
+                ancillary_devices_not_to_retry)
+
+    def update_retries_map_and_remove_devs_not_to_retry(
+            self, failed_devices, failed_ancillary_devices,
+            failed_devices_retries_map):
+        (new_failed_devices_retries_map, devices_not_to_retry,
+         ancillary_devices_not_to_retry) = self._get_devices_not_to_retry(
+            failed_devices, failed_ancillary_devices,
+            failed_devices_retries_map)
+        self._remove_devices_not_to_retry(
+            failed_devices, failed_ancillary_devices, devices_not_to_retry,
+            ancillary_devices_not_to_retry)
+        return new_failed_devices_retries_map
+
     def rpc_loop(self, polling_manager=None):
         if not polling_manager:
             polling_manager = polling.get_polling_manager(
@@ -1863,7 +1921,7 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         ports_not_ready_yet = set()
         failed_devices = {'added': set(), 'removed': set()}
         failed_ancillary_devices = {'added': set(), 'removed': set()}
-
+        failed_devices_retries_map = {}
         while self._check_and_handle_signal():
             if self.fullsync:
                 LOG.info(_LI("rpc_loop doing a full sync."))
@@ -1979,6 +2037,10 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                         ancillary_ports = ancillary_port_info['current']
 
                     polling_manager.polling_completed()
+                    failed_devices_retries_map = (
+                        self.update_retries_map_and_remove_devs_not_to_retry(
+                            failed_devices, failed_ancillary_devices,
+                            failed_devices_retries_map))
                     # Keep this flag in the last line of "try" block,
                     # so we can sure that no other Exception occurred.
                     ovs_restarted = False

--- a/neutron/tests/functional/agent/l2/base.py
+++ b/neutron/tests/functional/agent/l2/base.py
@@ -122,13 +122,38 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
         if tunnel_types:
             self.addCleanup(self.ovs.delete_bridge, self.br_tun)
         agent.sg_agent = mock.Mock()
+        agent.ancillary_brs = []
         return agent
 
-    def start_agent(self, agent, unplug_ports=None):
+    def _mock_get_events(self, agent, polling_manager, ports):
+        get_events = polling_manager.get_events
+        p_ids = [p['id'] for p in ports]
+
+        def filter_events():
+            events = get_events()
+            filtered_ports = []
+            for dev in events['added']:
+                iface_id = agent.int_br.portid_from_external_ids(
+                    dev.get('external_ids', []))
+                if iface_id in p_ids:
+                    # if the event is not about a port that was created by
+                    # this test, we filter the event out. Since these tests are
+                    # not run in isolation processing all the events might make
+                    # some test fail ( e.g. the agent might keep resycing
+                    # because it keeps finding not ready ports that are created
+                    # by other tests)
+                    filtered_ports.append(dev)
+            return {'added': filtered_ports, 'removed': events['removed']}
+        polling_manager.get_events = mock.Mock(side_effect=filter_events)
+
+    def start_agent(self, agent, ports=None, unplug_ports=None):
         if unplug_ports is None:
             unplug_ports = []
+        if ports is None:
+            ports = []
         self.setup_agent_rpc_mocks(agent, unplug_ports)
         polling_manager = polling.InterfacePollingMinimizer()
+        self._mock_get_events(agent, polling_manager, ports)
         self.addCleanup(polling_manager.stop)
         polling_manager.start()
         agent_utils.wait_until_true(
@@ -142,6 +167,7 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
             rpc_loop_thread.wait()
 
         self.addCleanup(stop_agent, agent, t)
+        return polling_manager
 
     def _create_test_port_dict(self):
         return {'id': uuidutils.generate_uuid(),
@@ -288,10 +314,10 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
 
     def setup_agent_and_ports(self, port_dicts, create_tunnels=True,
                               trigger_resync=False, network=None):
-        self.agent = self.create_agent(create_tunnels=create_tunnels)
-        self.start_agent(self.agent)
-        self.network = network or self._create_test_network_dict()
         self.ports = port_dicts
+        self.agent = self.create_agent(create_tunnels=create_tunnels)
+        self.polling_manager = self.start_agent(self.agent, ports=self.ports)
+        self.network = network or self._create_test_network_dict()
         if trigger_resync:
             self._prepare_resync_trigger(self.agent)
         self._plug_ports(self.network, self.ports, self.agent)

--- a/neutron/tests/functional/agent/l2/base.py
+++ b/neutron/tests/functional/agent/l2/base.py
@@ -102,7 +102,7 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
             'br_tun': br_tun.OVSTunnelBridge
         }
 
-    def create_agent(self, create_tunnels=True):
+    def create_agent(self, create_tunnels=True, ancillary_bridge=None):
         if create_tunnels:
             tunnel_types = [p_const.TYPE_VXLAN]
         else:
@@ -123,6 +123,8 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
             self.addCleanup(self.ovs.delete_bridge, self.br_tun)
         agent.sg_agent = mock.Mock()
         agent.ancillary_brs = []
+        if ancillary_bridge:
+            agent.ancillary_brs.append(ancillary_bridge)
         return agent
 
     def _mock_get_events(self, agent, polling_manager, ports):
@@ -255,7 +257,13 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
         else:
             rpc_devices = [
                 dev for args in call.call_args_list for dev in args[0][2]]
-        return not (set(expected_devices) - set(rpc_devices))
+        for dev in rpc_devices:
+            if dev in expected_devices:
+                expected_devices.remove(dev)
+        # reset mock otherwise if the mock is called again the same call param
+        # will be processed again
+        call.reset_mock()
+        return not expected_devices
 
     def create_test_ports(self, amount=3, **kwargs):
         ports = []
@@ -305,6 +313,53 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
         self.agent.plugin_rpc.update_device_list.side_effect = (
             mock_device_raise_exception)
 
+    def _prepare_failed_dev_up_trigger(self, agent):
+
+        def mock_failed_devices_up(context, devices_up, devices_down,
+                                   agent_id, host=None):
+            failed_devices = []
+            devices = list(devices_up)
+            # first port fails
+            if self.ports[0]['id'] in devices_up:
+                # reassign side_effect so that next RPC call will succeed
+                agent.plugin_rpc.update_device_list.side_effect = (
+                    self._mock_update_device)
+                devices.remove(self.ports[0]['id'])
+                failed_devices.append(self.ports[0]['id'])
+            return {'devices_up': devices,
+                    'failed_devices_up': failed_devices,
+                    'devices_down': [],
+                    'failed_devices_down': []}
+
+        self.agent.plugin_rpc.update_device_list.side_effect = (
+            mock_failed_devices_up)
+
+    def _prepare_failed_dev_down_trigger(self, agent):
+
+        def mock_failed_devices_down(context, devices_up, devices_down,
+                                     agent_id, host=None):
+            # first port fails
+            failed_port_id = self.ports[0]['id']
+            failed_devices_down = []
+            dev_down = [
+                {'device': p['id'], 'exists': True}
+                for p in self.ports if p['id'] in devices_down and (
+                    p['id'] != failed_port_id)]
+            # check if it's the call to set devices down and if the device
+            # that is supposed to fail is in the call then modify the
+            # side_effect so that next RPC call will succeed.
+            if devices_down and failed_port_id in devices_down:
+                agent.plugin_rpc.update_device_list.side_effect = (
+                     self._mock_update_device)
+                failed_devices_down.append(failed_port_id)
+            return {'devices_up': devices_up,
+                    'failed_devices_up': [],
+                    'devices_down': dev_down,
+                    'failed_devices_down': failed_devices_down}
+
+        self.agent.plugin_rpc.update_device_list.side_effect = (
+            mock_failed_devices_down)
+
     def wait_until_ports_state(self, ports, up, timeout=60):
         port_ids = [p['id'] for p in ports]
         agent_utils.wait_until_true(
@@ -313,14 +368,25 @@ class OVSAgentTestFramework(base.BaseOVSLinuxTestCase):
             timeout=timeout)
 
     def setup_agent_and_ports(self, port_dicts, create_tunnels=True,
-                              trigger_resync=False, network=None):
+                              network=None,
+                              ancillary_bridge=None,
+                              trigger_resync=False,
+                              failed_dev_up=False,
+                              failed_dev_down=False):
         self.ports = port_dicts
-        self.agent = self.create_agent(create_tunnels=create_tunnels)
+        self.agent = self.create_agent(create_tunnels=create_tunnels,
+                                       ancillary_bridge=ancillary_bridge)
         self.polling_manager = self.start_agent(self.agent, ports=self.ports)
         self.network = network or self._create_test_network_dict()
         if trigger_resync:
             self._prepare_resync_trigger(self.agent)
-        self._plug_ports(self.network, self.ports, self.agent)
+        elif failed_dev_up:
+            self._prepare_failed_dev_up_trigger(self.agent)
+        elif failed_dev_down:
+            self._prepare_failed_dev_down_trigger(self.agent)
+
+        self._plug_ports(self.network, self.ports, self.agent,
+                         bridge=ancillary_bridge)
 
     def plug_ports_to_phys_br(self, network, ports, namespace=None):
         physical_network = network.get('physical_network', 'physnet')

--- a/neutron/tests/functional/agent/test_l2_ovs_agent.py
+++ b/neutron/tests/functional/agent/test_l2_ovs_agent.py
@@ -185,7 +185,8 @@ class TestOVSAgent(base.OVSAgentTestFramework):
         self.agent = self.create_agent(create_tunnels=False)
         self.network = self._create_test_network_dict()
         self._plug_ports(self.network, self.ports, self.agent)
-        self.start_agent(self.agent, unplug_ports=[self.ports[1]])
+        self.start_agent(self.agent, ports=self.ports,
+                         unplug_ports=[self.ports[1]])
         self.wait_until_ports_state([self.ports[0]], up=True)
         self.assertRaises(
             Timeout, self.wait_until_ports_state, [self.ports[1]], up=True,

--- a/neutron/tests/unit/agent/l3/test_agent.py
+++ b/neutron/tests/unit/agent/l3/test_agent.py
@@ -203,6 +203,7 @@ class TestBasicRouterOperations(BasicRouterOperationsFramework):
 
     def test_periodic_sync_routers_task_raise_exception(self):
         agent = l3_agent.L3NATAgent(HOSTNAME, self.conf)
+        self.plugin_api.get_router_ids.return_value = ['fake_id']
         self.plugin_api.get_routers.side_effect = ValueError
         self.assertRaises(ValueError,
                           agent.periodic_sync_routers_task,
@@ -250,6 +251,8 @@ class TestBasicRouterOperations(BasicRouterOperationsFramework):
         agent = l3_agent.L3NATAgent(HOSTNAME, self.conf)
         stale_router_ids = [_uuid(), _uuid()]
         active_routers = [{'id': _uuid()}, {'id': _uuid()}]
+        self.plugin_api.get_router_ids.return_value = [r['id'] for r
+                                                       in active_routers]
         self.plugin_api.get_routers.return_value = active_routers
         namespace_list = [namespaces.NS_PREFIX + r_id
                           for r_id in stale_router_ids]

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
@@ -165,16 +165,19 @@ class TestOvsNeutronAgent(object):
         with mock.patch.object(self.agent, 'int_br', autospec=True) as int_br:
             int_br.db_get_val.return_value = db_get_val
             int_br.set_db_attribute.return_value = True
-            self.agent.port_bound(port, net_uuid, 'local', None, None,
-                                  fixed_ips, "compute:None", False)
+            needs_binding = self.agent.port_bound(
+                port, net_uuid, 'local', None, None,
+                fixed_ips, "compute:None", False)
         if db_get_val is None:
             self.assertEqual(0, int_br.set_db_attribute.call_count)
+            self.assertFalse(needs_binding)
         else:
             vlan_mapping = {'net_uuid': net_uuid,
                             'network_type': 'local',
                             'physical_network': None}
             int_br.set_db_attribute.assert_called_once_with(
                 "Port", mock.ANY, "other_config", vlan_mapping)
+            self.assertTrue(needs_binding)
 
     def test_datapath_type_system(self):
         # verify kernel datapath is default

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
@@ -592,6 +592,32 @@ class TestOvsNeutronAgent(object):
                 vif_port_set, registered_ports, port_tags_dict=port_tags_dict)
         self.assertEqual(expected, actual)
 
+    def test_update_retries_map_and_remove_devs_not_to_retry(self):
+        failed_devices_retries_map = {
+            'device_not_to_retry': constants.MAX_DEVICE_RETRIES,
+            'device_to_retry': 2,
+            'ancillary_not_to_retry': constants.MAX_DEVICE_RETRIES,
+            'ancillary_to_retry': 1}
+        failed_devices = {
+            'added': set(['device_not_to_retry']),
+            'removed': set(['device_to_retry', 'new_device'])}
+        failed_ancillary_devices = {'added': set(['ancillary_to_retry']),
+                                    'removed': set(['ancillary_not_to_retry'])}
+        expected_failed_devices_retries_map = {
+            'device_to_retry': 3, 'new_device': 1, 'ancillary_to_retry': 2}
+        (new_failed_devices_retries_map, devices_not_to_retry,
+         ancillary_devices_not_t_retry) = self.agent._get_devices_not_to_retry(
+            failed_devices, failed_ancillary_devices,
+            failed_devices_retries_map)
+        self.agent._remove_devices_not_to_retry(
+            failed_devices, failed_ancillary_devices, devices_not_to_retry,
+            ancillary_devices_not_t_retry)
+        self.assertIn('device_to_retry', failed_devices['removed'])
+        self.assertNotIn('device_not_to_retry', failed_devices['added'])
+        self.assertEqual(
+            expected_failed_devices_retries_map,
+            new_failed_devices_retries_map)
+
     def test_add_port_tag_info(self):
         self.agent.local_vlan_map["net1"] = mock.Mock()
         self.agent.local_vlan_map["net1"].vlan = "1"

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
@@ -428,6 +428,133 @@ class TestOvsNeutronAgent(object):
                                       updated_ports)
         self.assertEqual(expected, actual)
 
+    def _test_process_ports_events(self, events, registered_ports,
+                                   ancillary_ports, expected_ports,
+                                   expected_ancillary, updated_ports=None):
+        with mock.patch.object(self.agent, 'check_changed_vlans',
+                               return_value=set()):
+            devices_not_ready_yet = set()
+            actual = self.agent.process_ports_events(
+                events, registered_ports, ancillary_ports,
+                devices_not_ready_yet, updated_ports)
+            self.assertEqual(
+                (expected_ports, expected_ancillary, devices_not_ready_yet),
+                actual)
+
+    def test_process_ports_events_returns_current_for_unchanged_ports(self):
+        events = {'added': [], 'removed': []}
+        registered_ports = {1, 3}
+        ancillary_ports = {2, 5}
+        expected_ports = {'current': registered_ports, 'added': set(),
+                          'removed': set()}
+        expected_ancillary = {'current': ancillary_ports, 'added': set(),
+                              'removed': set()}
+        self._test_process_ports_events(events, registered_ports,
+                                        ancillary_ports, expected_ports,
+                                        expected_ancillary)
+
+    def test_process_port_events_no_vif_changes_return_updated_port_only(self):
+        events = {'added': [], 'removed': []}
+        registered_ports = {1, 2, 3}
+        updated_ports = {2}
+        expected_ports = dict(current=registered_ports, updated={2},
+                              added=set(), removed=set())
+        expected_ancillary = dict(current=set(), added=set(), removed=set())
+        self._test_process_ports_events(events, registered_ports,
+                                        set(), expected_ports,
+                                        expected_ancillary, updated_ports)
+
+    def test_process_port_events_ignores_removed_port_if_never_added(self):
+        events = {'added': [],
+                  'removed': [{'name': 'port2', 'ofport': 2,
+                               'external_ids': {'attached-mac': 'test-mac'}}]}
+        registered_ports = {1}
+        expected_ports = dict(current=registered_ports, added=set(),
+                              removed=set())
+        expected_ancillary = dict(current=set(), added=set(), removed=set())
+        devices_not_ready_yet = set()
+        with mock.patch.object(self.agent.int_br, 'portid_from_external_ids',
+                               side_effect=[2]), \
+            mock.patch.object(self.agent, 'check_changed_vlans',
+                              return_value=set()):
+            actual = self.agent.process_ports_events(
+                events, registered_ports, set(), devices_not_ready_yet)
+            self.assertEqual(
+                (expected_ports, expected_ancillary, devices_not_ready_yet),
+                actual)
+
+    def test_process_port_events_port_not_ready_yet(self):
+        events = {'added': [{'name': 'port5', 'ofport': [],
+                  'external_ids': {'attached-mac': 'test-mac'}}],
+                  'removed': []}
+        old_devices_not_ready = {'port4'}
+        registered_ports = set([1, 2, 3])
+        expected_ports = dict(current=set([1, 2, 3, 4]),
+                              added=set([4]), removed=set())
+        self.agent.ancillary_brs = []
+        expected_ancillary = dict(current=set(), added=set(), removed=set())
+        with mock.patch.object(self.agent.int_br, 'portid_from_external_ids',
+                               side_effect=[5, 4]), \
+            mock.patch.object(self.agent, 'check_changed_vlans',
+                              return_value=set()), \
+            mock.patch.object(self.agent.int_br, 'get_ports_attributes',
+                              return_value=[{'name': 'port4', 'ofport': 4,
+                                             'external_ids': {
+                                                 'attached-mac': 'mac4'}}]):
+            expected_devices_not_ready = {'port5'}
+            actual = self.agent.process_ports_events(
+                events, registered_ports, set(), old_devices_not_ready)
+            self.assertEqual(
+                (expected_ports, expected_ancillary,
+                 expected_devices_not_ready),
+                actual)
+
+    def _test_process_port_events_with_updated_ports(self, updated_ports):
+        events = {'added': [{'name': 'port3', 'ofport': 3,
+                            'external_ids': {'attached-mac': 'test-mac'}},
+                            {'name': 'qg-port2', 'ofport': 6,
+                             'external_ids': {'attached-mac': 'test-mac'}}],
+                  'removed': [{'name': 'port2', 'ofport': 2,
+                               'external_ids': {'attached-mac': 'test-mac'}},
+                              {'name': 'qg-port1', 'ofport': 5,
+                               'external_ids': {'attached-mac': 'test-mac'}}]}
+        registered_ports = {1, 2, 4}
+        ancillary_ports = {5, 8}
+        expected_ports = dict(current={1, 3, 4}, added={3}, removed={2})
+        if updated_ports:
+            expected_ports['updated'] = updated_ports
+        expected_ancillary = dict(current={6, 8}, added={6},
+                                  removed={5})
+        ancillary_bridge = mock.Mock()
+        ancillary_bridge.get_vif_port_set.return_value = {5, 6, 8}
+        self.agent.ancillary_brs = [ancillary_bridge]
+        with mock.patch.object(self.agent.int_br, 'portid_from_external_ids',
+                              side_effect=[3, 6, 2, 5]), \
+            mock.patch.object(self.agent, 'check_changed_vlans',
+                              return_value=set()):
+
+            devices_not_ready_yet = set()
+            actual = self.agent.process_ports_events(
+                events, registered_ports, ancillary_ports,
+                devices_not_ready_yet, updated_ports)
+            self.assertEqual(
+                (expected_ports, expected_ancillary, devices_not_ready_yet),
+                actual)
+
+    def test_process_port_events_returns_port_changes(self):
+        self._test_process_port_events_with_updated_ports(set())
+
+    def test_process_port_events_finds_known_updated_ports(self):
+        self._test_process_port_events_with_updated_ports({4})
+
+    def test_process_port_events_ignores_unknown_updated_ports(self):
+        # the port '10' was not seen on current ports. Hence it has either
+        # never been wired or already removed and should be ignored
+        self._test_process_port_events_with_updated_ports({4, 10})
+
+    def test_process_port_events_ignores_updated_port_if_removed(self):
+        self._test_process_port_events_with_updated_ports({4, 5})
+
     def test_update_ports_returns_changed_vlan(self):
         br = self.br_int_cls('br-int')
         mac = "ca:fe:de:ad:be:ef"
@@ -1430,11 +1557,17 @@ class TestOvsNeutronAgent(object):
 
         self.agent.enable_tunneling = True
 
+        reply_ancillary = {'current': set([]),
+                           'added': set([]),
+                           'removed': set([])}
+
         with mock.patch.object(async_process.AsyncProcess, "_spawn"),\
+                mock.patch.object(async_process.AsyncProcess, "start"),\
+                mock.patch.object(async_process.AsyncProcess, "stop"),\
                 mock.patch.object(log.KeywordArgumentAdapter,
                                   'exception') as log_exception,\
                 mock.patch.object(self.mod_agent.OVSNeutronAgent,
-                                  'scan_ports') as scan_ports,\
+                                  'process_ports_events') as process_p_events,\
                 mock.patch.object(
                     self.mod_agent.OVSNeutronAgent,
                     'process_network_ports') as process_network_ports,\
@@ -1460,7 +1593,11 @@ class TestOvsNeutronAgent(object):
                     '_reset_tunnel_ofports') as reset_tunnel_ofports:
             log_exception.side_effect = Exception(
                 'Fake exception to get out of the loop')
-            scan_ports.side_effect = [reply2, reply3]
+            devices_not_ready = set()
+            process_p_events.side_effect = [(reply2, reply_ancillary,
+                                             devices_not_ready),
+                                            (reply3, reply_ancillary,
+                                             devices_not_ready)]
             process_network_ports.side_effect = [
                 False, Exception('Fake exception to get out of the loop')]
             check_ovs_status.side_effect = args
@@ -1469,10 +1606,13 @@ class TestOvsNeutronAgent(object):
             except Exception:
                 pass
 
-            scan_ports.assert_has_calls([
-                mock.call(set(), True, set()),
-                mock.call(set(), False, set())
+            process_p_events.assert_has_calls([
+                mock.call({'removed': [], 'added': []}, set(), set(), set(),
+                          set()),
+                mock.call({'removed': [], 'added': []}, set(['tap0']), set(),
+                          set(), set())
             ])
+
             process_network_ports.assert_has_calls([
                 mock.call(reply2, False),
                 mock.call(reply3, True)

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
@@ -430,13 +430,18 @@ class TestOvsNeutronAgent(object):
 
     def _test_process_ports_events(self, events, registered_ports,
                                    ancillary_ports, expected_ports,
-                                   expected_ancillary, updated_ports=None):
+                                   expected_ancillary, updated_ports=None,
+                                   ):
         with mock.patch.object(self.agent, 'check_changed_vlans',
                                return_value=set()):
             devices_not_ready_yet = set()
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_ancillary_devices = {
+                'added': set(), 'removed': set()}
             actual = self.agent.process_ports_events(
                 events, registered_ports, ancillary_ports,
-                devices_not_ready_yet, updated_ports)
+                devices_not_ready_yet, failed_devices,
+                failed_ancillary_devices, updated_ports)
             self.assertEqual(
                 (expected_ports, expected_ancillary, devices_not_ready_yet),
                 actual)
@@ -477,8 +482,13 @@ class TestOvsNeutronAgent(object):
                                side_effect=[2]), \
             mock.patch.object(self.agent, 'check_changed_vlans',
                               return_value=set()):
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_ancillary_devices = {
+                'added': set(), 'removed': set()}
+            ports_not_ready_yet = set()
             actual = self.agent.process_ports_events(
-                events, registered_ports, set(), devices_not_ready_yet)
+                events, registered_ports, set(), ports_not_ready_yet,
+                failed_devices, failed_ancillary_devices)
             self.assertEqual(
                 (expected_ports, expected_ancillary, devices_not_ready_yet),
                 actual)
@@ -502,12 +512,15 @@ class TestOvsNeutronAgent(object):
                                              'external_ids': {
                                                  'attached-mac': 'mac4'}}]):
             expected_devices_not_ready = {'port5'}
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_ancillary_devices = {
+                'added': set(), 'removed': set()}
             actual = self.agent.process_ports_events(
-                events, registered_ports, set(), old_devices_not_ready)
+                events, registered_ports, set(), old_devices_not_ready,
+                failed_devices, failed_ancillary_devices)
             self.assertEqual(
                 (expected_ports, expected_ancillary,
-                 expected_devices_not_ready),
-                actual)
+                 expected_devices_not_ready), actual)
 
     def _test_process_port_events_with_updated_ports(self, updated_ports):
         events = {'added': [{'name': 'port3', 'ofport': 3,
@@ -534,9 +547,13 @@ class TestOvsNeutronAgent(object):
                               return_value=set()):
 
             devices_not_ready_yet = set()
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_ancillary_devices = {
+                'added': set(), 'removed': set()}
             actual = self.agent.process_ports_events(
                 events, registered_ports, ancillary_ports,
-                devices_not_ready_yet, updated_ports)
+                devices_not_ready_yet, failed_devices,
+                failed_ancillary_devices, updated_ports)
             self.assertEqual(
                 (expected_ports, expected_ancillary, devices_not_ready_yet),
                 actual)
@@ -685,7 +702,7 @@ class TestOvsNeutronAgent(object):
         with mock.patch.object(self.agent.plugin_rpc,
                                'get_devices_details_list_and_failed_devices',
                                return_value={'devices': [details],
-                                             'failed_devices': None}),\
+                                             'failed_devices': []}),\
                 mock.patch.object(self.agent.int_br,
                                   'get_vifs_by_ids',
                                   return_value={details['device']: port}),\
@@ -698,8 +715,8 @@ class TestOvsNeutronAgent(object):
                     'get_port_tag_dict',
                     return_value={}),\
                 mock.patch.object(self.agent, func_name) as func:
-            skip_devs, need_bound_devices, insecure_ports = (
-                self.agent.treat_devices_added_or_updated([{}], False))
+            skip_devs, need_bound_devices, insecure_ports, _ = (
+                self.agent.treat_devices_added_or_updated([], False))
             # The function should not raise
             self.assertFalse(skip_devs)
             return func.called
@@ -743,7 +760,7 @@ class TestOvsNeutronAgent(object):
         with mock.patch.object(self.agent.plugin_rpc,
                                'get_devices_details_list_and_failed_devices',
                                return_value={'devices': [details],
-                                             'failed_devices': None}),\
+                                             'failed_devices': []}),\
             mock.patch.object(self.agent.ext_manager,
                               'handle_port', new=fake_handle_port),\
             mock.patch.object(self.agent.int_br,
@@ -752,7 +769,7 @@ class TestOvsNeutronAgent(object):
             mock.patch.object(self.agent, 'treat_vif_port',
                               return_value=False):
 
-            self.agent.treat_devices_added_or_updated([{}], False)
+            self.agent.treat_devices_added_or_updated([], False)
 
     def test_treat_devices_added_updated_skips_if_port_not_found(self):
         dev_mock = mock.MagicMock()
@@ -760,7 +777,7 @@ class TestOvsNeutronAgent(object):
         with mock.patch.object(self.agent.plugin_rpc,
                                'get_devices_details_list_and_failed_devices',
                                return_value={'devices': [dev_mock],
-                                             'failed_devices': None}),\
+                                             'failed_devices': []}),\
                 mock.patch.object(self.agent.int_br,
                     'get_port_tag_dict',
                     return_value={}),\
@@ -769,10 +786,29 @@ class TestOvsNeutronAgent(object):
                                   return_value={}),\
                 mock.patch.object(self.agent,
                                   'treat_vif_port') as treat_vif_port:
-            skip_devs = self.agent.treat_devices_added_or_updated([{}], False)
+            skip_devs = self.agent.treat_devices_added_or_updated([], False)
             # The function should return False for resync and no device
             # processed
-            self.assertEqual((['the_skipped_one'], [], []), skip_devs)
+            self.assertEqual((['the_skipped_one'], [], [], set()), skip_devs)
+            self.assertFalse(treat_vif_port.called)
+
+    def test_treat_devices_added_failed_devices(self):
+        dev_mock = 'the_failed_one'
+        with mock.patch.object(self.agent.plugin_rpc,
+                               'get_devices_details_list_and_failed_devices',
+                               return_value={'devices': [],
+                                             'failed_devices': [dev_mock]}),\
+                mock.patch.object(self.agent.int_br,
+                                  'get_vifs_by_ids',
+                                  return_value={}),\
+                mock.patch.object(self.agent,
+                                  'treat_vif_port') as treat_vif_port:
+            failed_devices = {'added': set(), 'removed': set()}
+            (_, _, _, failed_devices['added']) = (
+                self.agent.treat_devices_added_or_updated([], False))
+            # The function should return False for resync and no device
+            # processed
+            self.assertEqual(set([dev_mock]), failed_devices.get('added'))
             self.assertFalse(treat_vif_port.called)
 
     def test_treat_devices_added_updated_put_port_down(self):
@@ -792,7 +828,7 @@ class TestOvsNeutronAgent(object):
         with mock.patch.object(self.agent.plugin_rpc,
                                'get_devices_details_list_and_failed_devices',
                                return_value={'devices': [fake_details_dict],
-                                             'failed_devices': None}),\
+                                             'failed_devices': []}),\
                 mock.patch.object(self.agent.int_br,
                                   'get_vifs_by_ids',
                                   return_value={'xxx': mock.MagicMock()}),\
@@ -800,8 +836,8 @@ class TestOvsNeutronAgent(object):
                                   return_value={}),\
                 mock.patch.object(self.agent,
                                   'treat_vif_port') as treat_vif_port:
-            skip_devs, need_bound_devices, insecure_ports = (
-                self.agent.treat_devices_added_or_updated([{}], False))
+            skip_devs, need_bound_devices, insecure_ports, _ = (
+                self.agent.treat_devices_added_or_updated([], False))
             # The function should return False for resync
             self.assertFalse(skip_devs)
             self.assertTrue(treat_vif_port.called)
@@ -824,6 +860,19 @@ class TestOvsNeutronAgent(object):
     def test_treat_devices_removed_ignores_missing_port(self):
         self._mock_treat_devices_removed(False)
 
+    def test_treat_devices_removed_failed_devices(self):
+        dev_mock = 'the_failed_one'
+        with mock.patch.object(self.agent.plugin_rpc,
+                               'update_device_list',
+                               return_value={'devices_up': [],
+                                             'devices_down': [],
+                                             'failed_devices_up': [],
+                                             'failed_devices_down': [
+                                                 dev_mock]}):
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_devices['removed'] = self.agent.treat_devices_removed([{}])
+            self.assertEqual(set([dev_mock]), failed_devices.get('removed'))
+
     def test_bind_port_with_missing_network(self):
         vif_port = mock.Mock()
         vif_port.name.return_value = 'port'
@@ -831,19 +880,24 @@ class TestOvsNeutronAgent(object):
                                    'vif_port': vif_port}])
 
     def _test_process_network_ports(self, port_info):
+        failed_devices = {'added': set(), 'removed': set()}
         with mock.patch.object(self.agent.sg_agent,
                                "setup_port_filters") as setup_port_filters,\
                 mock.patch.object(
-                    self.agent,
-                    "treat_devices_added_or_updated",
-                    return_value=([], [], [])) as device_added_updated,\
+                    self.agent, "treat_devices_added_or_updated",
+                    return_value=(
+                        [], [], [],
+                        failed_devices['added'])) as device_added_updated,\
                 mock.patch.object(self.agent.int_br, "get_ports_attributes",
                                   return_value=[]),\
                 mock.patch.object(self.agent,
                                   "treat_devices_removed",
-                                  return_value=False) as device_removed:
-            self.assertFalse(self.agent.process_network_ports(port_info,
-                                                              False))
+                                  return_value=(
+                                      failed_devices[
+                                          'removed'])) as device_removed:
+            self.assertEqual(
+                failed_devices,
+                self.agent.process_network_ports(port_info, False))
             setup_port_filters.assert_called_once_with(
                 port_info.get('added', set()),
                 port_info.get('updated', set()))
@@ -876,14 +930,18 @@ class TestOvsNeutronAgent(object):
                      'updated': set(['tap1']),
                      'removed': set([]),
                      'added': set(['eth1'])}
+        failed_dev = {'added': set(), 'removed': set()}
         with mock.patch.object(self.agent.sg_agent,
                                "setup_port_filters") as setup_port_filters,\
                 mock.patch.object(
                     self.agent,
                     "treat_devices_added_or_updated",
-                    return_value=([], [], ['eth1'])) as device_added_updated:
-            self.assertFalse(self.agent.process_network_ports(port_info,
-                                                              False))
+                    return_value=(
+                        [], [], ['eth1'],
+                        failed_dev['added'])) as device_added_updated:
+            self.assertEqual(
+                failed_dev,
+                self.agent.process_network_ports(port_info, False))
             device_added_updated.assert_called_once_with(
                 set(['eth1', 'tap1']), False)
             setup_port_filters.assert_called_once_with(
@@ -1598,8 +1656,11 @@ class TestOvsNeutronAgent(object):
                                              devices_not_ready),
                                             (reply3, reply_ancillary,
                                              devices_not_ready)]
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_ancillary_devices = {'added': set(), 'removed': set()}
             process_network_ports.side_effect = [
-                False, Exception('Fake exception to get out of the loop')]
+                failed_devices,
+                Exception('Fake exception to get out of the loop')]
             check_ovs_status.side_effect = args
             try:
                 self.agent.daemon_loop()
@@ -1608,9 +1669,11 @@ class TestOvsNeutronAgent(object):
 
             process_p_events.assert_has_calls([
                 mock.call({'removed': [], 'added': []}, set(), set(), set(),
+                          failed_devices, failed_ancillary_devices,
                           set()),
                 mock.call({'removed': [], 'added': []}, set(['tap0']), set(),
-                          set(), set())
+                          set(), failed_devices, failed_ancillary_devices,
+                          set())
             ])
 
             process_network_ports.assert_has_calls([
@@ -1655,7 +1718,7 @@ class TestOvsNeutronAgent(object):
                 mock.patch.object(
                     self.mod_agent.OVSNeutronAgent,
                     '_check_and_handle_signal') as check_and_handle_signal:
-            process_network_ports.return_value = True
+            process_network_ports.side_effect = Exception("Trigger resync")
             check_ovs_status.return_value = constants.OVS_NORMAL
             check_and_handle_signal.side_effect = [True, False]
             self.agent.daemon_loop()
@@ -2484,7 +2547,9 @@ class TestOvsDvrNeutronAgent(object):
                 mock.patch.object(self.agent.dvr_agent, 'tun_br', new=tun_br),\
                 mock.patch.dict(self.agent.dvr_agent.phys_brs,
                                 {self._physical_network: phys_br}):
-            self.agent.treat_devices_removed([self._port.vif_id])
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_devices['removed'] = self.agent.treat_devices_removed(
+                [self._port.vif_id])
             lvid = self.agent.local_vlan_map[self._net_uuid].vlan
             if ip_version == 4:
                 expected = [
@@ -2598,7 +2663,9 @@ class TestOvsDvrNeutronAgent(object):
                 mock.patch.object(self.agent, 'tun_br', new=tun_br),\
                 mock.patch.object(self.agent.dvr_agent, 'int_br', new=int_br),\
                 mock.patch.object(self.agent.dvr_agent, 'tun_br', new=tun_br):
-            self.agent.treat_devices_removed([self._compute_port.vif_id])
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_devices['removed'] = self.agent.treat_devices_removed(
+                [self._compute_port.vif_id])
             int_br.assert_has_calls([
                 mock.call.delete_dvr_to_src_mac(
                     network_type='vxlan',
@@ -2694,7 +2761,9 @@ class TestOvsDvrNeutronAgent(object):
                 mock.patch.object(self.agent, 'tun_br', new=tun_br),\
                 mock.patch.object(self.agent.dvr_agent, 'int_br', new=int_br),\
                 mock.patch.object(self.agent.dvr_agent, 'tun_br', new=tun_br):
-            self.agent.treat_devices_removed([self._port.vif_id])
+            failed_devices = {'added': set(), 'removed': set()}
+            failed_devices['removed'] = self.agent.treat_devices_removed(
+                [self._port.vif_id])
             expected_on_int_br = [
                 mock.call.delete_dvr_to_src_mac(
                     network_type='vxlan',

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_tunnel.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_tunnel.py
@@ -530,11 +530,15 @@ class TunnelTest(object):
         self._verify_mock_calls()
 
     def test_daemon_loop(self):
-        reply_ge_1 = {'added': set(['tap0']),
-                      'removed': set([])}
+        reply_ge_1 = {'added': [{'name': 'tap0', 'ofport': 3,
+                                 'external_ids': {
+                                     'attached-mac': 'test_mac'}}],
+                      'removed': []}
 
-        reply_ge_2 = {'added': set([]),
-                  'removed': set(['tap0'])}
+        reply_ge_2 = {'added': [],
+                      'removed': [{'name': 'tap0', 'ofport': 3,
+                                   'external_ids': {
+                                       'attached-mac': 'test_mac'}}]}
 
         reply_pe_1 = {'current': set(['tap0']),
                       'added': set(['tap0']),
@@ -569,13 +573,7 @@ class TunnelTest(object):
                                   'process_ports_events') as process_p_events,\
                 mock.patch.object(
                     self.mod_agent.OVSNeutronAgent,
-                    'scan_ancillary_ports') as scan_ancillary_ports,\
-                mock.patch.object(
-                    self.mod_agent.OVSNeutronAgent,
                     'process_network_ports') as process_network_ports,\
-                mock.patch.object(
-                    self.mod_agent.OVSNeutronAgent,
-                    'process_ancillary_network_ports') as process_anc_ports,\
                 mock.patch.object(self.mod_agent.OVSNeutronAgent,
                                   'tunnel_sync'),\
                 mock.patch.object(time, 'sleep'),\
@@ -584,9 +582,6 @@ class TunnelTest(object):
                     'update_stale_ofport_rules') as update_stale:
             log_exception.side_effect = Exception(
                 'Fake exception to get out of the loop')
-            scan_ancillary_ports.return_value = {
-                'current': set([]), 'added': set([]), 'removed': set([]),
-            }
             update_stale.return_value = []
             devices_not_ready = set()
             process_p_events.side_effect = [
@@ -594,9 +589,11 @@ class TunnelTest(object):
                 (reply_pe_2, reply_ancillary, devices_not_ready)]
             interface_polling = mock.Mock()
             interface_polling.get_events.side_effect = [reply_ge_1, reply_ge_2]
+            failed_devices = {'removed': set([]), 'added': set([])}
+            failed_ancillary_devices = {'removed': set([]), 'added': set([])}
             process_network_ports.side_effect = [
-                False, Exception('Fake exception to get out of the loop')]
-            process_anc_ports.return_value = False
+                failed_devices,
+                Exception('Fake exception to get out of the loop')]
 
             n_agent = self._build_agent()
 
@@ -613,8 +610,10 @@ class TunnelTest(object):
             log_exception.assert_called_once_with(
                 "Error while processing VIF ports")
             process_p_events.assert_has_calls([
-                mock.call(reply_ge_1, set(), set(), devices_not_ready, set()),
+                mock.call(reply_ge_1, set(), set(), devices_not_ready,
+                          failed_devices, failed_ancillary_devices, set()),
                 mock.call(reply_ge_2, set(['tap0']), set(), devices_not_ready,
+                          failed_devices, failed_ancillary_devices,
                           set())
             ])
             process_network_ports.assert_has_calls([


### PR DESCRIPTION
Updating agents table is contantious operation which
can fail often if mysql backend is in multimaster mode.
This could lead to agents flapping and various issues
such as sporadic reschedluing, port binding failures, etc.

Change-Id: Ief392f9a09d86c185dc086055d2cbc1891ff1d7f
Closes-Bug: #1560724
(cherry picked from commit d5e4013556c7144d347ece267c4bd3c8dc87b24f)

Conflicts:
    neutron/db/agents_db.py
