### PR TITLE
OVS: compare names when checking devices both added and deleted

### DIFF
--- a/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/ml2/drivers/openvswitch/agent/ovs_neutron_agent.py
@@ -1293,13 +1293,16 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         # if a port was added and then removed or viceversa since the agent
         # can't know the order of the operations, check the status of the port
         # to determine if the port was added or deleted
-        ports_removed_and_added = [
-            p for p in events['added'] if p in events['removed']]
+        added_ports = {p['name'] for p in events['added']}
+        removed_ports = {p['name'] for p in events['removed']}
+        ports_removed_and_added = added_ports & removed_ports
         for p in ports_removed_and_added:
-            if ovs_lib.BaseOVS().port_exists(p['name']):
-                events['removed'].remove(p)
+            if ovs_lib.BaseOVS().port_exists(p):
+                events['removed'] = [e for e in events['removed']
+                                     if e['name'] != p]
             else:
-                events['added'].remove(p)
+                events['added'] = [e for e in events['added']
+                                   if e['name'] != p]
 
         #TODO(rossella_s): scanning the ancillary bridge won't be needed
         # anymore when https://review.openstack.org/#/c/203381 since the bridge

--- a/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
+++ b/neutron/tests/unit/plugins/ml2/drivers/openvswitch/agent/test_ovs_neutron_agent.py
@@ -446,6 +446,43 @@ class TestOvsNeutronAgent(object):
                 (expected_ports, expected_ancillary, devices_not_ready_yet),
                 actual)
 
+    def test_process_ports_events_port_removed_and_added(self):
+        port_id = 'f6f104bd-37c7-4f7b-9d70-53a6bb42728f'
+        events = {
+            'removed':
+                [{'ofport': 1,
+                  'external_ids': {'iface-id': port_id,
+                                   'attached-mac': 'fa:16:3e:f6:1b:fb'},
+                  'name': 'qvof6f104bd-37'}],
+            'added':
+                [{'ofport': 2,
+                  'external_ids': {'iface-id': port_id,
+                                   'attached-mac': 'fa:16:3e:f6:1b:fb'},
+                  'name': 'qvof6f104bd-37'}]
+        }
+        registered_ports = {port_id}
+        expected_ancillary = dict(current=set(), added=set(), removed=set())
+
+        # port was removed and then added
+        expected_ports = dict(current={port_id},
+                              added={port_id},
+                              removed=set())
+        with mock.patch.object(ovs_lib.BaseOVS, "port_exists",
+                               return_value=True):
+            self._test_process_ports_events(events.copy(), registered_ports,
+                                            set(), expected_ports,
+                                            expected_ancillary)
+
+        # port was added and then removed
+        expected_ports = dict(current=set(),
+                              added=set(),
+                              removed={port_id})
+        with mock.patch.object(ovs_lib.BaseOVS, "port_exists",
+                               return_value=False):
+            self._test_process_ports_events(events.copy(), registered_ports,
+                                            set(), expected_ports,
+                                            expected_ancillary)
+
     def test_process_ports_events_returns_current_for_unchanged_ports(self):
         events = {'added': [], 'removed': []}
         registered_ports = {1, 3}


### PR DESCRIPTION
When processing events from ovsdb monitor, agent checks devices
for which there are both 'added' and 'deleted' events and then looks
for the device in the system to know what event could be omitted.
In some cases event dicts for same port would not be equal:
for example ofports may differ. Thus we should compare device names
rather than dicts.
Please see bug for more details.

Closes-Bug: #1585623
Change-Id: I93e8796ce4a94327c1e96b19f8183c97546e193d