### PR TITLE
Reduce cost of in memory iptables management

### DIFF
--- a/neutron/agent/linux/iptables_firewall.py
+++ b/neutron/agent/linux/iptables_firewall.py
@@ -219,8 +219,8 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
             port = ports[pname]
             self._setup_chain(port, firewall.INGRESS_DIRECTION)
             self._setup_chain(port, firewall.EGRESS_DIRECTION)
-        self.iptables.ipv4['filter'].add_rule(SG_CHAIN, '-j ACCEPT')
-        self.iptables.ipv6['filter'].add_rule(SG_CHAIN, '-j ACCEPT')
+        self.iptables.ipv4['filter'].add_rule(SG_CHAIN, '-j ACCEPT', tag=SG_CHAIN)
+        self.iptables.ipv6['filter'].add_rule(SG_CHAIN, '-j ACCEPT', tag=SG_CHAIN)
 
         for port in unfiltered_ports.values():
             self._add_accept_rule_port_sec(port, firewall.INGRESS_DIRECTION)
@@ -267,22 +267,22 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
         self.iptables.ipv6['filter'].add_chain(chain_name)
 
     def _remove_raw_chain(self, chain_name):
-        self.iptables.ipv4['raw'].remove_chain(chain_name)
-        self.iptables.ipv6['raw'].remove_chain(chain_name)
+        self.iptables.ipv4['raw'].remove_chain_by_tag(chain_name, chain_name)
+        self.iptables.ipv6['raw'].remove_chain_by_tag(chain_name, chain_name)
 
     def _remove_chain_by_name_v4v6(self, chain_name):
-        self.iptables.ipv4['filter'].remove_chain(chain_name)
-        self.iptables.ipv6['filter'].remove_chain(chain_name)
+        self.iptables.ipv4['filter'].remove_chain_by_tag(chain_name, chain_name)
+        self.iptables.ipv6['filter'].remove_chain_by_tag(chain_name, chain_name)
 
     def _add_rules_to_chain_v4v6(self, chain_name, ipv4_rules, ipv6_rules,
-                                 comment=None):
+                                 comment=None, tag=None):
         for rule in ipv4_rules:
             self.iptables.ipv4['filter'].add_rule(chain_name, rule,
-                                                  comment=comment)
+                                                  comment=comment, tag=tag)
 
         for rule in ipv6_rules:
             self.iptables.ipv6['filter'].add_rule(chain_name, rule,
-                                                  comment=comment)
+                                                  comment=comment, tag=tag)
 
     def _get_device_name(self, port):
         return port['device']
@@ -290,13 +290,14 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
     def _update_port_sec_rules(self, port, direction, add=False):
         # add/remove rules in FORWARD and INPUT chain
         device = self._get_device_name(port)
+	chain_name = self._port_chain_name(port, direction)
 
         jump_rule = ['-m physdev --%s %s --physdev-is-bridged '
                      '-j ACCEPT' % (self.IPTABLES_DIRECTION[direction],
                                     device)]
         if add:
             self._add_rules_to_chain_v4v6(
-                'FORWARD', jump_rule, jump_rule, comment=ic.PORT_SEC_ACCEPT)
+                'FORWARD', jump_rule, jump_rule, comment=ic.PORT_SEC_ACCEPT, tag=chain_name)
         else:
             self._remove_rule_from_chain_v4v6('FORWARD', jump_rule, jump_rule)
 
@@ -306,7 +307,8 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
                                         device)]
             if add:
                 self._add_rules_to_chain_v4v6('INPUT', jump_rule, jump_rule,
-                                              comment=ic.PORT_SEC_ACCEPT)
+                                              comment=ic.PORT_SEC_ACCEPT, tag=chain_name)
+
             else:
                 self._remove_rule_from_chain_v4v6(
                     'INPUT', jump_rule, jump_rule)
@@ -327,7 +329,7 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
                                  device,
                                  SG_CHAIN)]
         self._add_rules_to_chain_v4v6('FORWARD', jump_rule, jump_rule,
-                                      comment=ic.VM_INT_SG)
+                                      comment=ic.VM_INT_SG, tag=chain_name)
 
         # jump to the chain based on the device
         jump_rule = ['-m physdev --%s %s --physdev-is-bridged '
@@ -335,11 +337,11 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
                                  device,
                                  chain_name)]
         self._add_rules_to_chain_v4v6(SG_CHAIN, jump_rule, jump_rule,
-                                      comment=ic.SG_TO_VM_SG)
+                                      comment=ic.SG_TO_VM_SG, tag=chain_name)
 
         if direction == firewall.EGRESS_DIRECTION:
             self._add_rules_to_chain_v4v6('INPUT', jump_rule, jump_rule,
-                                          comment=ic.INPUT_TO_SG)
+                                          comment=ic.INPUT_TO_SG, tag=chain_name)
 
     def _split_sgr_by_ethertype(self, security_group_rules):
         ipv4_sg_rules = []
@@ -368,14 +370,14 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
                     # of the list after the allowed_address_pair rules.
                     table.add_rule(chain_name,
                                    '-m mac --mac-source %s -j RETURN'
-                                   % mac.upper(), comment=ic.PAIR_ALLOW)
+                                   % mac.upper(), comment=ic.PAIR_ALLOW, tag=chain_name)
                 else:
                     # we need to convert it into a prefix to match iptables
                     ip = c_utils.ip_to_cidr(ip)
                     table.add_rule(chain_name,
                                    '-s %s -m mac --mac-source %s -j RETURN'
-                                   % (ip, mac.upper()), comment=ic.PAIR_ALLOW)
-            table.add_rule(chain_name, '-j DROP', comment=ic.PAIR_DROP)
+                                   % (ip, mac.upper()), comment=ic.PAIR_ALLOW, tag=chain_name)
+            table.add_rule(chain_name, '-j DROP', comment=ic.PAIR_DROP, tag=chain_name)
             rules.append('-j $%s' % chain_name)
 
     def _build_ipv4v6_mac_ip_list(self, mac, ip_address, mac_ipv4_pairs,
@@ -530,9 +532,10 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
         ipv6_iptables_rules += self._convert_sgr_to_iptables_rules(
             ipv6_sg_rules)
         # finally add the rules to the port chain for a given direction
-        self._add_rules_to_chain_v4v6(self._port_chain_name(port, direction),
+        chain_name = self._port_chain_name(port, direction)
+        self._add_rules_to_chain_v4v6(chain_name,
                                       ipv4_iptables_rules,
-                                      ipv6_iptables_rules)
+                                      ipv6_iptables_rules, tag=chain_name)
 
     def _add_fixed_egress_rules(self, port, ipv4_iptables_rules,
                                 ipv6_iptables_rules):
@@ -937,6 +940,7 @@ class OVSHybridIptablesFirewallDriver(IptablesFirewallDriver):
 
     def _add_raw_chain_rules(self, port, direction):
         jump_rule = self._get_jump_rule(port, direction)
+        # Didn't tag rule since 'PREROUTING' chain isn't handled by IptablesFirewallDriver
         self.iptables.ipv4['raw'].add_rule('PREROUTING', jump_rule)
         self.iptables.ipv6['raw'].add_rule('PREROUTING', jump_rule)
 

--- a/neutron/agent/linux/iptables_manager.py
+++ b/neutron/agent/linux/iptables_manager.py
@@ -121,7 +121,39 @@ class IptablesRule(object):
         return comment_rule('-A %s %s' % (chain, self.rule), self.comment)
 
 
-class IptablesTable(object):
+class IptablesTableBase(object):
+    """A noop version of iptables table."""
+
+    def __init__(self, binary_name=binary_name):
+        return
+
+    def add_chain(self, name, wrap=True):
+        return
+
+    def remove_chain(self, name, wrap=True):
+        return
+
+    def remove_chain_by_tag(self, name, tag, wrap=True):
+        return
+
+    def add_rule(self, chain, rule, wrap=True, top=False, tag=None,
+                 comment=None):
+        return
+
+    def remove_rule(self, chain, rule, wrap=True, top=False, comment=None):
+        return
+
+    def empty_chain(self, chain, wrap=True):
+        return
+
+    def clear_rules_by_tag(self, tag):
+        return
+
+    def clear_rules_by_tag_nowrap(self, tag):
+        return
+
+
+class IptablesTable(IptablesTableBase):
     """An iptables table."""
 
     def __init__(self, binary_name=binary_name):
@@ -199,6 +231,35 @@ class IptablesTable(object):
         self.rules = [r for r in self.rules
                       if jump_snippet not in r.rule]
 
+    def remove_chain_by_tag(self, name, tag, wrap=True):
+        """Remove named chain.
+
+        This removal "cascades". All rule in the chain are removed, as are
+        all rules in other chains that jump to it.
+
+        If the chain is not found, this is merely logged.
+
+        """
+        name = get_chain_name(name, wrap)
+        chain_set = self._select_chain_set(wrap)
+
+        if name not in chain_set:
+            LOG.debug('Attempted to remove chain %s which does not exist',
+                      name)
+            return
+
+        chain_set.remove(name)
+
+        if not wrap:
+            # non-wrapped chains and rules need to be dealt with specially,
+            # so we keep a list of them to be iterated over in apply()
+            self.remove_chains.add(name)
+
+        if not wrap:
+            self.remove_rules += self.clear_rules_by_tag_nowrap(tag)
+        else:
+            self.clear_rules_by_tag(tag)
+
     def add_rule(self, chain, rule, wrap=True, top=False, tag=None,
                  comment=None):
         """Add a rule to the table.
@@ -269,9 +330,21 @@ class IptablesTable(object):
     def clear_rules_by_tag(self, tag):
         if not tag:
             return
-        rules = [rule for rule in self.rules if rule.tag == tag]
-        for rule in rules:
-            self.rules.remove(rule)
+        self.rules = [rule for rule in self.rules if rule.tag != tag]
+
+    def clear_rules_by_tag_nowrap(self, tag):
+        if not tag:
+            return
+        rules = []
+        rules_removed = []
+        for rule in self.rules:
+            if rule.tag == tag:
+                rules_removed.add(rule)
+            else:
+                rules.add(rule)
+
+        self.rules = rules
+        return rules_removed
 
 
 class IptablesManager(object):
@@ -310,7 +383,11 @@ class IptablesManager(object):
         self.wrap_name = binary_name[:16]
 
         self.ipv4 = {'filter': IptablesTable(binary_name=self.wrap_name)}
-        self.ipv6 = {'filter': IptablesTable(binary_name=self.wrap_name)}
+        if self.use_ipv6:
+            self.ipv6 = {'filter': IptablesTable(binary_name=self.wrap_name)}
+        else:
+            self.ipv6 = {'filter':
+                         IptablesTableBase(binary_name=self.wrap_name)}
 
         # Add a neutron-filter-top chain. It's intended to be shared
         # among the various neutron components. It sits at the very top

--- a/neutron/tests/unit/agent/linux/test_iptables_firewall.py
+++ b/neutron/tests/unit/agent/linux/test_iptables_firewall.py
@@ -27,7 +27,6 @@ from neutron.agent.linux import iptables_firewall
 from neutron.agent import securitygroups_rpc as sg_cfg
 from neutron.common import constants
 from neutron.common import exceptions as n_exc
-from neutron.common import ipv6_utils
 from neutron.common import utils
 from neutron.tests import base
 from neutron.tests.unit.api.v2 import test_base
@@ -92,8 +91,6 @@ class BaseIptablesFirewallTestCase(base.BaseTestCase):
 
         self.iptables_inst.get_rules_for_table.return_value = (
             RAW_TABLE_OUTPUT.splitlines())
-#NJR
-#        ipv6_utils._IS_IPV6_ENABLED = True
         self.firewall = iptables_firewall.IptablesFirewallDriver()
         self.firewall.iptables = self.iptables_inst
 
@@ -1952,8 +1949,6 @@ class OVSHybridIptablesFirewallTestCase(BaseIptablesFirewallTestCase):
 
     def setUp(self):
         super(OVSHybridIptablesFirewallTestCase, self).setUp()
-# NJR
-#        ipv6_utils._IS_IPV6_ENABLED = true
         self.firewall = iptables_firewall.OVSHybridIptablesFirewallDriver()
         # inital data has 1, 2, and 9 in use, see RAW_TABLE_OUTPUT above.
         self._dev_zone_map = {'61634509-31': 2, '8f46cf18-12': 9,

--- a/neutron/tests/unit/agent/linux/test_iptables_firewall.py
+++ b/neutron/tests/unit/agent/linux/test_iptables_firewall.py
@@ -27,6 +27,7 @@ from neutron.agent.linux import iptables_firewall
 from neutron.agent import securitygroups_rpc as sg_cfg
 from neutron.common import constants
 from neutron.common import exceptions as n_exc
+from neutron.common import ipv6_utils
 from neutron.common import utils
 from neutron.tests import base
 from neutron.tests.unit.api.v2 import test_base
@@ -91,6 +92,8 @@ class BaseIptablesFirewallTestCase(base.BaseTestCase):
 
         self.iptables_inst.get_rules_for_table.return_value = (
             RAW_TABLE_OUTPUT.splitlines())
+#NJR
+#        ipv6_utils._IS_IPV6_ENABLED = True
         self.firewall = iptables_firewall.IptablesFirewallDriver()
         self.firewall.iptables = self.iptables_inst
 
@@ -111,78 +114,82 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                  mock.call.add_rule(
                      'sg-fallback', '-j DROP',
                      comment=ic.UNMATCH_DROP),
-                 mock.call.remove_chain('sg-chain'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain'),
                  mock.call.add_chain('ifake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ifake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
                                     '-j $ifake_dev',
-                                    comment=ic.SG_TO_VM_SG),
+                                    comment=ic.SG_TO_VM_SG,
+                                    tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
                      '-m state --state INVALID -j DROP',
-                     comment=None),
+                     comment=None, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-j $sg-fallback', comment=None),
+                     '-j $sg-fallback', comment=None, tag='ifake_dev'),
                  mock.call.add_chain('ofake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ofake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged -j $ofake_dev',
-                                    comment=ic.SG_TO_VM_SG),
+                                    comment=ic.SG_TO_VM_SG, tag='ofake_dev'),
                  mock.call.add_rule('INPUT',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged -j $ofake_dev',
-                                    comment=ic.INPUT_TO_SG),
+                                    comment=ic.INPUT_TO_SG, tag='ofake_dev'),
                  mock.call.add_chain('sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev',
                      '-s 10.0.0.1/32 -m mac --mac-source FF:FF:FF:FF:FF:FF '
                      '-j RETURN',
-                     comment=ic.PAIR_ALLOW),
+                     comment=ic.PAIR_ALLOW, tag='sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev', '-j DROP',
-                     comment=ic.PAIR_DROP),
+                     comment=ic.PAIR_DROP, tag='sfake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp '
                      '--sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j $sfake_dev',
-                                    comment=None),
+                                    comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 67 -m udp --dport 68 -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-j $sg-fallback',
-                     comment=None),
-                 mock.call.add_rule('sg-chain', '-j ACCEPT')]
+                     comment=None, tag='ofake_dev'),
+                 mock.call.add_rule('sg-chain', '-j ACCEPT', tag='sg-chain')]
 
         self.v4filter_inst.assert_has_calls(calls)
 
@@ -190,7 +197,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         rule = {'ethertype': 'IPv4',
                 'direction': 'ingress'}
         ingress = mock.call.add_rule('ifake_dev', '-j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -200,7 +207,8 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-s %s -j RETURN' % prefix, comment=None)
+            'ifake_dev', '-s %s -j RETURN' % prefix, comment=None,
+            tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -209,7 +217,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'protocol': 'tcp'}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-p tcp -j RETURN', comment=None)
+            'ifake_dev', '-p tcp -j RETURN', comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -221,7 +229,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-s %s -p tcp -j RETURN' % prefix,
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -230,7 +238,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'protocol': 'icmp'}
         ingress = mock.call.add_rule('ifake_dev', '-p icmp -j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -242,7 +250,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule(
             'ifake_dev', '-s %s -p icmp -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -254,7 +262,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-p tcp -m tcp --dport 10 -j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -267,7 +275,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-p tcp -m tcp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -282,7 +290,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-s %s -p tcp -m tcp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -291,7 +299,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'protocol': 'udp'}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-p udp -j RETURN', comment=None)
+            'ifake_dev', '-p udp -j RETURN', comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -303,7 +311,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-s %s -p udp -j RETURN' % prefix,
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -315,7 +323,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-p udp -m udp --dport 10 -j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -328,7 +336,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-p udp -m udp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -343,14 +351,15 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-s %s -p udp -m udp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv4_egress(self):
         rule = {'ethertype': 'IPv4',
                 'direction': 'egress'}
-        egress = mock.call.add_rule('ofake_dev', '-j RETURN', comment=None)
+        egress = mock.call.add_rule('ofake_dev', '-j RETURN', comment=None,
+                tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -360,7 +369,8 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule(
-            'ofake_dev', '-s %s -j RETURN' % prefix, comment=None)
+            'ofake_dev', '-s %s -j RETURN' % prefix, comment=None,
+            tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -369,7 +379,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'protocol': 'tcp'}
         egress = mock.call.add_rule(
-            'ofake_dev', '-p tcp -j RETURN', comment=None)
+            'ofake_dev', '-p tcp -j RETURN', comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -381,7 +391,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule('ofake_dev',
                                     '-s %s -p tcp -j RETURN' % prefix,
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -390,7 +400,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'protocol': 'icmp'}
         egress = mock.call.add_rule('ofake_dev', '-p icmp -j RETURN',
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -402,7 +412,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule(
             'ofake_dev', '-s %s -p icmp -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -416,7 +426,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p icmp -m icmp --icmp-type 8 -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -431,7 +441,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
             'ofake_dev',
             '-s %s -p icmp -m icmp --icmp-type echo-request '
             '-j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -446,7 +456,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p icmp -m icmp --icmp-type 8/0 -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -458,7 +468,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         egress = mock.call.add_rule('ofake_dev',
                                     '-p tcp -m tcp --dport 10 -j RETURN',
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -471,7 +481,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-p tcp -m tcp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -486,7 +496,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p tcp -m tcp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -495,7 +505,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'protocol': 'udp'}
         egress = mock.call.add_rule(
-            'ofake_dev', '-p udp -j RETURN', comment=None)
+            'ofake_dev', '-p udp -j RETURN', comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -507,7 +517,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule('ofake_dev',
                                     '-s %s -p udp -j RETURN' % prefix,
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -519,7 +529,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         egress = mock.call.add_rule('ofake_dev',
                                     '-p udp -m udp --dport 10 -j RETURN',
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -532,7 +542,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-p udp -m udp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -547,7 +557,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p udp -m udp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -555,7 +565,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress'}
         ingress = mock.call.add_rule('ifake_dev', '-j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -565,7 +575,8 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-s %s -j RETURN' % prefix, comment=None)
+            'ifake_dev', '-s %s -j RETURN' % prefix, comment=None,
+            tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -574,7 +585,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'protocol': 'tcp'}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-p tcp -j RETURN', comment=None)
+            'ifake_dev', '-p tcp -j RETURN', comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -586,7 +597,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-s %s -p tcp -j RETURN' % prefix,
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -598,7 +609,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-p tcp -m tcp --dport 10 -j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -607,7 +618,8 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'protocol': 'icmp'}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-p ipv6-icmp -j RETURN', comment=None)
+            'ifake_dev', '-p ipv6-icmp -j RETURN', comment=None,
+            tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -619,7 +631,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule(
             'ifake_dev', '-s %s -p ipv6-icmp -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -632,7 +644,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-p tcp -m tcp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -645,7 +657,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-p tcp -m tcp -m multiport --dports 0:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -666,7 +678,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-s %s -p tcp -m tcp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -675,7 +687,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'ingress',
                 'protocol': 'udp'}
         ingress = mock.call.add_rule(
-            'ifake_dev', '-p udp -j RETURN', comment=None)
+            'ifake_dev', '-p udp -j RETURN', comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -687,7 +699,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-s %s -p udp -j RETURN' % prefix,
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -699,7 +711,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         ingress = mock.call.add_rule('ifake_dev',
                                      '-p udp -m udp --dport 10 -j RETURN',
-                                     comment=None)
+                                     comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -712,7 +724,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-p udp -m udp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -727,14 +739,15 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         ingress = mock.call.add_rule(
             'ifake_dev',
             '-s %s -p udp -m udp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ifake_dev')
         egress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress(self):
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress'}
-        egress = mock.call.add_rule('ofake_dev', '-j RETURN', comment=None)
+        egress = mock.call.add_rule('ofake_dev', '-j RETURN', comment=None,
+                tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -744,7 +757,8 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule(
-            'ofake_dev', '-s %s -j RETURN' % prefix, comment=None)
+            'ofake_dev', '-s %s -j RETURN' % prefix, comment=None,
+            tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -753,7 +767,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'protocol': 'tcp'}
         egress = mock.call.add_rule(
-            'ofake_dev', '-p tcp -j RETURN', comment=None)
+            'ofake_dev', '-p tcp -j RETURN', comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -765,7 +779,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule('ofake_dev',
                                     '-s %s -p tcp -j RETURN' % prefix,
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -774,7 +788,8 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'protocol': 'icmp'}
         egress = mock.call.add_rule(
-            'ofake_dev', '-p ipv6-icmp -j RETURN', comment=None)
+            'ofake_dev', '-p ipv6-icmp -j RETURN', comment=None,
+            tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -786,7 +801,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule(
             'ofake_dev', '-s %s -p ipv6-icmp -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -800,7 +815,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p ipv6-icmp -m icmp6 --icmpv6-type 8 -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -815,7 +830,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
             'ofake_dev',
             '-s %s -p ipv6-icmp -m icmp6 --icmpv6-type echo-request '
             '-j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -830,7 +845,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p ipv6-icmp -m icmp6 --icmpv6-type 8/0 -j RETURN' % prefix,
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -842,7 +857,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         egress = mock.call.add_rule('ofake_dev',
                                     '-p tcp -m tcp --dport 10 -j RETURN',
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -855,7 +870,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-p tcp -m tcp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -870,7 +885,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p tcp -m tcp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -879,7 +894,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'direction': 'egress',
                 'protocol': 'udp'}
         egress = mock.call.add_rule(
-            'ofake_dev', '-p udp -j RETURN', comment=None)
+            'ofake_dev', '-p udp -j RETURN', comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -891,7 +906,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'source_ip_prefix': prefix}
         egress = mock.call.add_rule('ofake_dev',
                                     '-s %s -p udp -j RETURN' % prefix,
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -903,7 +918,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                 'port_range_max': 10}
         egress = mock.call.add_rule('ofake_dev',
                                     '-p udp -m udp --dport 10 -j RETURN',
-                                    comment=None)
+                                    comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -916,7 +931,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-p udp -m udp -m multiport --dports 10:100 -j RETURN',
-            comment=None)
+            comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -931,7 +946,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
         egress = mock.call.add_rule(
             'ofake_dev',
             '-s %s -p udp -m udp -m multiport --dports 10:100 '
-            '-j RETURN' % prefix, comment=None)
+            '-j RETURN' % prefix, comment=None, tag='ofake_dev')
         ingress = None
         self._test_prepare_port_filter(rule, ingress, egress)
 
@@ -947,7 +962,7 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
             'ofake_dev',
             '-s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp '
             '--sport 68 --dport 67 -j RETURN',
-            comment=None)]
+            comment=None, tag='ofake_dev')]
 
         if ethertype == 'IPv6':
             filter_inst = self.v6filter_inst
@@ -956,17 +971,17 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                                             '-s ::/128 -d ff02::/16 '
                                             '-p ipv6-icmp -m icmp6 '
                                             '--icmpv6-type 131 -j RETURN',
-                                            comment=None),
+                                            comment=None, tag='ofake_dev'),
                          mock.call.add_rule('ofake_dev',
                                             '-s ::/128 -d ff02::/16 '
                                             '-p ipv6-icmp -m icmp6 '
                                             '--icmpv6-type 135 -j RETURN',
-                                            comment=None),
+                                            comment=None, tag='ofake_dev'),
                          mock.call.add_rule('ofake_dev',
                                             '-s ::/128 -d ff02::/16 '
                                             '-p ipv6-icmp -m icmp6 '
                                             '--icmpv6-type 143 -j RETURN',
-                                            comment=None)]
+                                            comment=None, tag='ofake_dev')]
         sg = [rule]
         port['security_group_rules'] = sg
         self.firewall.prepare_port_filter(port)
@@ -975,18 +990,19 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                      'sg-fallback',
                      '-j DROP',
                      comment=ic.UNMATCH_DROP),
-                 mock.call.remove_chain('sg-chain'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain'),
                  mock.call.add_chain('ifake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ifake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
                                     '-j $ifake_dev',
-                                    comment=ic.SG_TO_VM_SG)
+                                    comment=ic.SG_TO_VM_SG, tag='ifake_dev')
                  ]
         if ethertype == 'IPv6':
             for icmp6_type in constants.ICMPV6_ALLOWED_TYPES:
@@ -994,12 +1010,13 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                     mock.call.add_rule('ifake_dev',
                                        '-p ipv6-icmp -m icmp6 --icmpv6-type '
                                        '%s -j RETURN' %
-                                       icmp6_type, comment=None))
+                                       icmp6_type, comment=None,
+                                       tag='ifake_dev'))
         calls += [
             mock.call.add_rule(
                 'ifake_dev',
                 '-m state --state RELATED,ESTABLISHED -j RETURN',
-                comment=None
+                comment=None, tag='ifake_dev'
             )
         ]
 
@@ -1008,70 +1025,74 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
 
         calls += [mock.call.add_rule(
                       'ifake_dev',
-                      '-m state --state INVALID -j DROP', comment=None),
+                      '-m state --state INVALID -j DROP', comment=None,
+                      tag='ifake_dev'),
                   mock.call.add_rule('ifake_dev',
-                                     '-j $sg-fallback', comment=None),
+                                     '-j $sg-fallback', comment=None,
+                                     tag='ifake_dev'),
                   mock.call.add_chain('ofake_dev'),
                   mock.call.add_rule('FORWARD',
                                      '-m physdev --physdev-in tapfake_dev '
                                      '--physdev-is-bridged '
-                                     '-j $sg-chain', comment=ic.VM_INT_SG),
+                                     '-j $sg-chain', comment=ic.VM_INT_SG,
+                                     tag='ofake_dev'),
                   mock.call.add_rule('sg-chain',
                                      '-m physdev --physdev-in tapfake_dev '
                                      '--physdev-is-bridged -j $ofake_dev',
-                                     comment=ic.SG_TO_VM_SG),
+                                     comment=ic.SG_TO_VM_SG, tag='ofake_dev'),
                   mock.call.add_rule('INPUT',
                                      '-m physdev --physdev-in tapfake_dev '
                                      '--physdev-is-bridged -j $ofake_dev',
-                                     comment=ic.INPUT_TO_SG),
+                                     comment=ic.INPUT_TO_SG, tag='ofake_dev'),
                   mock.call.add_chain('sfake_dev'),
                   mock.call.add_rule(
                       'sfake_dev',
                       '-s %s -m mac --mac-source FF:FF:FF:FF:FF:FF -j RETURN'
                       % prefix,
-                      comment=ic.PAIR_ALLOW)]
+                      comment=ic.PAIR_ALLOW, tag='sfake_dev')]
 
         if ethertype == 'IPv6':
             calls.append(mock.call.add_rule('sfake_dev',
                 '-s fe80::fdff:ffff:feff:ffff/128 -m mac '
                 '--mac-source FF:FF:FF:FF:FF:FF -j RETURN',
-                comment=ic.PAIR_ALLOW))
+                comment=ic.PAIR_ALLOW, tag='sfake_dev'))
         calls.append(mock.call.add_rule('sfake_dev', '-j DROP',
-                                        comment=ic.PAIR_DROP))
+                                        comment=ic.PAIR_DROP, tag='sfake_dev'))
         calls += dhcp_rule
         calls.append(mock.call.add_rule('ofake_dev', '-j $sfake_dev',
-                                        comment=None))
+                                        comment=None, tag='ofake_dev'))
         if ethertype == 'IPv4':
             calls.append(mock.call.add_rule(
                 'ofake_dev',
                 '-p udp -m udp --sport 68 --dport 67 -j RETURN',
-                comment=None))
+                comment=None, tag='ofake_dev'))
             calls.append(mock.call.add_rule(
                 'ofake_dev',
                 '-p udp -m udp --sport 67 -m udp --dport 68 -j DROP',
-                comment=None))
+                comment=None, tag='ofake_dev'))
         if ethertype == 'IPv6':
             calls.append(mock.call.add_rule('ofake_dev',
                                             '-p ipv6-icmp -m icmp6 '
                                             '--icmpv6-type %s -j DROP' %
                                             constants.ICMPV6_TYPE_RA,
-                                            comment=None))
+                                            comment=None, tag='ofake_dev'))
             calls.append(mock.call.add_rule('ofake_dev',
                                             '-p ipv6-icmp -j RETURN',
-                                            comment=None))
+                                            comment=None, tag='ofake_dev'))
             calls.append(mock.call.add_rule('ofake_dev', '-p udp -m udp '
                                             '--sport 546 -m udp --dport 547 '
-                                            '-j RETURN', comment=None))
+                                            '-j RETURN', comment=None,
+                                            tag='ofake_dev'))
             calls.append(mock.call.add_rule(
                 'ofake_dev',
                 '-p udp -m udp --sport 547 -m udp --dport 546 -j DROP',
-                comment=None))
+                comment=None, tag='ofake_dev'))
 
         calls += [
             mock.call.add_rule(
                 'ofake_dev',
                 '-m state --state RELATED,ESTABLISHED -j RETURN',
-                comment=None),
+                comment=None, tag='ofake_dev'),
         ]
 
         if egress_expected_call:
@@ -1079,10 +1100,12 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
 
         calls += [mock.call.add_rule(
                       'ofake_dev',
-                      '-m state --state INVALID -j DROP', comment=None),
+                      '-m state --state INVALID -j DROP', comment=None,
+                      tag='ofake_dev'),
                   mock.call.add_rule('ofake_dev',
-                                     '-j $sg-fallback', comment=None),
-                  mock.call.add_rule('sg-chain', '-j ACCEPT')]
+                                     '-j $sg-fallback', comment=None,
+                                     tag='ofake_dev'),
+                  mock.call.add_rule('sg-chain', '-j ACCEPT', tag='sg-chain')]
         comb = zip(calls, filter_inst.mock_calls)
         for (l, r) in comb:
             self.assertEqual(l, r)
@@ -1181,165 +1204,168 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                      'sg-fallback',
                      '-j DROP',
                      comment=ic.UNMATCH_DROP),
-                 mock.call.remove_chain('sg-chain'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain'),
                  mock.call.add_chain('ifake_dev'),
                  mock.call.add_rule(
                      'FORWARD',
                      '-m physdev --physdev-out tapfake_dev '
                      '--physdev-is-bridged -j $sg-chain',
-                     comment=ic.VM_INT_SG),
+                     comment=ic.VM_INT_SG, tag='ifake_dev'),
                  mock.call.add_rule(
                      'sg-chain',
                      '-m physdev --physdev-out tapfake_dev '
                      '--physdev-is-bridged -j $ifake_dev',
-                     comment=ic.SG_TO_VM_SG),
+                     comment=ic.SG_TO_VM_SG, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ifake_dev'),
                  mock.call.add_rule('ifake_dev', '-j RETURN',
-                                    comment=None),
+                                    comment=None, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-j $sg-fallback', comment=None),
+                     '-j $sg-fallback', comment=None, tag='ifake_dev'),
                  mock.call.add_chain('ofake_dev'),
                  mock.call.add_rule(
                      'FORWARD',
                      '-m physdev --physdev-in tapfake_dev '
                      '--physdev-is-bridged -j $sg-chain',
-                     comment=ic.VM_INT_SG),
+                     comment=ic.VM_INT_SG, tag='ofake_dev'),
                  mock.call.add_rule(
                      'sg-chain',
                      '-m physdev --physdev-in tapfake_dev '
                      '--physdev-is-bridged -j $ofake_dev',
-                     comment=ic.SG_TO_VM_SG),
+                     comment=ic.SG_TO_VM_SG, tag='ofake_dev'),
                  mock.call.add_rule(
                      'INPUT',
                      '-m physdev --physdev-in tapfake_dev '
                      '--physdev-is-bridged -j $ofake_dev',
-                     comment=ic.INPUT_TO_SG),
+                     comment=ic.INPUT_TO_SG, tag='ofake_dev'),
                  mock.call.add_chain('sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev',
                      '-s 10.0.0.1/32 -m mac --mac-source FF:FF:FF:FF:FF:FF '
                      '-j RETURN',
-                     comment=ic.PAIR_ALLOW),
+                     comment=ic.PAIR_ALLOW, tag='sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev', '-j DROP',
-                     comment=ic.PAIR_DROP),
+                     comment=ic.PAIR_DROP, tag='sfake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp '
                      '--sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j $sfake_dev',
-                                    comment=None),
+                                    comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 67 -m udp --dport 68 -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev', '-m state --state INVALID -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
-                     '-j $sg-fallback', comment=None),
-                 mock.call.add_rule('sg-chain', '-j ACCEPT'),
-                 mock.call.remove_chain('ifake_dev'),
-                 mock.call.remove_chain('ofake_dev'),
-                 mock.call.remove_chain('sfake_dev'),
-                 mock.call.remove_chain('sg-chain'),
+                     '-j $sg-fallback', comment=None, tag='ofake_dev'),
+                 mock.call.add_rule('sg-chain', '-j ACCEPT', tag='sg-chain'),
+                 mock.call.remove_chain_by_tag('ifake_dev', 'ifake_dev'),
+                 mock.call.remove_chain_by_tag('ofake_dev', 'ofake_dev'),
+                 mock.call.remove_chain_by_tag('sfake_dev', 'sfake_dev'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain'),
                  mock.call.add_chain('ifake_dev'),
                  mock.call.add_rule(
                      'FORWARD',
                      '-m physdev --physdev-out tapfake_dev '
                      '--physdev-is-bridged -j $sg-chain',
-                     comment=ic.VM_INT_SG),
+                     comment=ic.VM_INT_SG, tag='ifake_dev'),
                  mock.call.add_rule(
                      'sg-chain',
                      '-m physdev --physdev-out tapfake_dev '
                      '--physdev-is-bridged -j $ifake_dev',
-                     comment=ic.SG_TO_VM_SG),
+                     comment=ic.SG_TO_VM_SG, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-j $sg-fallback', comment=None),
+                     '-j $sg-fallback', comment=None, tag='ifake_dev'),
                  mock.call.add_chain('ofake_dev'),
                  mock.call.add_rule(
                      'FORWARD',
                      '-m physdev --physdev-in tapfake_dev '
                      '--physdev-is-bridged -j $sg-chain',
-                     comment=ic.VM_INT_SG),
+                     comment=ic.VM_INT_SG, tag='ofake_dev'),
                  mock.call.add_rule(
                      'sg-chain',
                      '-m physdev --physdev-in tapfake_dev '
                      '--physdev-is-bridged -j $ofake_dev',
-                     comment=ic.SG_TO_VM_SG),
+                     comment=ic.SG_TO_VM_SG, tag='ofake_dev'),
                  mock.call.add_rule(
                      'INPUT',
                      '-m physdev --physdev-in tapfake_dev '
                      '--physdev-is-bridged -j $ofake_dev',
-                     comment=ic.INPUT_TO_SG),
+                     comment=ic.INPUT_TO_SG, tag='ofake_dev'),
                  mock.call.add_chain('sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev',
                      '-s 10.0.0.1/32 -m mac --mac-source FF:FF:FF:FF:FF:FF '
                      '-j RETURN',
-                     comment=ic.PAIR_ALLOW),
+                     comment=ic.PAIR_ALLOW, tag='sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev', '-j DROP',
-                     comment=ic.PAIR_DROP),
+                     comment=ic.PAIR_DROP, tag='sfake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp '
                      '--sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j $sfake_dev',
-                                    comment=None),
+                                    comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 67 -m udp --dport 68 -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j RETURN',
-                                    comment=None),
+                                    comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev',
                                     '-j $sg-fallback',
-                                    comment=None),
-                 mock.call.add_rule('sg-chain', '-j ACCEPT'),
-                 mock.call.remove_chain('ifake_dev'),
-                 mock.call.remove_chain('ofake_dev'),
-                 mock.call.remove_chain('sfake_dev'),
-                 mock.call.remove_chain('sg-chain'),
+                                    comment=None, tag='ofake_dev'),
+                 mock.call.add_rule('sg-chain', '-j ACCEPT', tag='sg-chain'),
+                 mock.call.remove_chain_by_tag('ifake_dev', 'ifake_dev'),
+                 mock.call.remove_chain_by_tag('ofake_dev', 'ofake_dev'),
+                 mock.call.remove_chain_by_tag('sfake_dev', 'sfake_dev'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain')]
 
         self.v4filter_inst.assert_has_calls(calls)
@@ -1440,79 +1466,85 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                  mock.call.add_rule(
                      'sg-fallback', '-j DROP',
                      comment=ic.UNMATCH_DROP),
-                 mock.call.remove_chain('sg-chain'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain'),
                  mock.call.add_chain('ifake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ifake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
                                     '-j $ifake_dev',
-                                    comment=ic.SG_TO_VM_SG),
+                                    comment=ic.SG_TO_VM_SG, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ifake_dev'),
                  mock.call.add_rule('ifake_dev',
-                                    '-j $sg-fallback', comment=None),
+                                    '-j $sg-fallback', comment=None,
+                                    tag='ifake_dev'),
                  mock.call.add_chain('ofake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ofake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged -j $ofake_dev',
-                                    comment=ic.SG_TO_VM_SG),
+                                    comment=ic.SG_TO_VM_SG, tag='ofake_dev'),
                  mock.call.add_rule('INPUT',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged -j $ofake_dev',
-                                    comment=ic.INPUT_TO_SG),
+                                    comment=ic.INPUT_TO_SG, tag='ofake_dev'),
                  mock.call.add_chain('sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev',
                      '-s 10.0.0.1/32 -m mac --mac-source FF:FF:FF:FF:FF:FF '
                      '-j RETURN',
-                     comment=ic.PAIR_ALLOW),
+                     comment=ic.PAIR_ALLOW, tag='sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev',
                      '-s 10.0.0.2/32 -m mac --mac-source FF:FF:FF:FF:FF:FF '
                      '-j RETURN',
-                     comment=ic.PAIR_ALLOW),
+                     comment=ic.PAIR_ALLOW, tag='sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev', '-j DROP',
-                     comment=ic.PAIR_DROP),
+                     comment=ic.PAIR_DROP, tag='sfake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp '
                      '--sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j $sfake_dev',
-                                    comment=None),
+                                    comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 67 -m udp --dport 68 -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev',
-                                    '-j $sg-fallback', comment=None),
-                 mock.call.add_rule('sg-chain', '-j ACCEPT')]
+                                    '-j $sg-fallback', comment=None,
+                                    tag='ofake_dev'),
+                 mock.call.add_rule('sg-chain', '-j ACCEPT', tag='sg-chain')]
         self.v4filter_inst.assert_has_calls(calls)
 
     def test_ip_spoofing_no_fixed_ips(self):
@@ -1525,74 +1557,77 @@ class IptablesFirewallTestCase(BaseIptablesFirewallTestCase):
                  mock.call.add_rule(
                      'sg-fallback', '-j DROP',
                      comment=ic.UNMATCH_DROP),
-                 mock.call.remove_chain('sg-chain'),
+                 mock.call.remove_chain_by_tag('sg-chain', 'sg-chain'),
                  mock.call.add_chain('sg-chain'),
                  mock.call.add_chain('ifake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ifake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-out tapfake_dev '
                                     '--physdev-is-bridged '
                                     '-j $ifake_dev',
-                                    comment=ic.SG_TO_VM_SG),
+                                    comment=ic.SG_TO_VM_SG, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ifake_dev'),
                  mock.call.add_rule(
                      'ifake_dev',
-                     '-m state --state INVALID -j DROP', comment=None),
+                     '-m state --state INVALID -j DROP', comment=None,
+                     tag='ifake_dev'),
                  mock.call.add_rule('ifake_dev', '-j $sg-fallback',
-                                    comment=None),
+                                    comment=None, tag='ifake_dev'),
                  mock.call.add_chain('ofake_dev'),
                  mock.call.add_rule('FORWARD',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged '
-                                    '-j $sg-chain', comment=ic.VM_INT_SG),
+                                    '-j $sg-chain', comment=ic.VM_INT_SG,
+                                    tag='ofake_dev'),
                  mock.call.add_rule('sg-chain',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged -j $ofake_dev',
-                                    comment=ic.SG_TO_VM_SG),
+                                    comment=ic.SG_TO_VM_SG, tag='ofake_dev'),
                  mock.call.add_rule('INPUT',
                                     '-m physdev --physdev-in tapfake_dev '
                                     '--physdev-is-bridged -j $ofake_dev',
-                                    comment=ic.INPUT_TO_SG),
+                                    comment=ic.INPUT_TO_SG, tag='ofake_dev'),
                  mock.call.add_chain('sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev',
                      '-m mac --mac-source FF:FF:FF:FF:FF:FF -j RETURN',
-                     comment=ic.PAIR_ALLOW),
+                     comment=ic.PAIR_ALLOW, tag='sfake_dev'),
                  mock.call.add_rule(
                      'sfake_dev', '-j DROP',
-                     comment=ic.PAIR_DROP),
+                     comment=ic.PAIR_DROP, tag='sfake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-s 0.0.0.0/32 -d 255.255.255.255/32 -p udp -m udp '
                      '--sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j $sfake_dev',
-                                    comment=None),
+                                    comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 68 --dport 67 -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-p udp -m udp --sport 67 -m udp --dport 68 -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-m state --state RELATED,ESTABLISHED -j RETURN',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule(
                      'ofake_dev',
                      '-m state --state INVALID -j DROP',
-                     comment=None),
+                     comment=None, tag='ofake_dev'),
                  mock.call.add_rule('ofake_dev', '-j $sg-fallback',
-                                    comment=None),
-                 mock.call.add_rule('sg-chain', '-j ACCEPT')]
+                                    comment=None, tag='ofake_dev'),
+                 mock.call.add_rule('sg-chain', '-j ACCEPT', tag='sg-chain')]
         self.v4filter_inst.assert_has_calls(calls)
 
 
@@ -1767,9 +1802,11 @@ class IptablesFirewallEnhancedIpsetTestCase(BaseIptablesFirewallTestCase):
         v4_adds = self.firewall.iptables.ipv4['filter'].add_rule.mock_calls
         v6_adds = self.firewall.iptables.ipv6['filter'].add_rule.mock_calls
         sg_chain_v4_accept = [call for call in v4_adds
-                              if call == mock.call('sg-chain', '-j ACCEPT')]
+                              if call == mock.call('sg-chain', '-j ACCEPT',
+                                  tag='sg-chain')]
         sg_chain_v6_accept = [call for call in v6_adds
-                              if call == mock.call('sg-chain', '-j ACCEPT')]
+                              if call == mock.call('sg-chain', '-j ACCEPT',
+                                  tag='sg-chain')]
         self.assertEqual(1, len(sg_chain_v4_accept))
         self.assertEqual(1, len(sg_chain_v6_accept))
 
@@ -1915,6 +1952,8 @@ class OVSHybridIptablesFirewallTestCase(BaseIptablesFirewallTestCase):
 
     def setUp(self):
         super(OVSHybridIptablesFirewallTestCase, self).setUp()
+# NJR
+#        ipv6_utils._IS_IPV6_ENABLED = true
         self.firewall = iptables_firewall.OVSHybridIptablesFirewallDriver()
         # inital data has 1, 2, and 9 in use, see RAW_TABLE_OUTPUT above.
         self._dev_zone_map = {'61634509-31': 2, '8f46cf18-12': 9,

--- a/neutron/tests/unit/agent/test_securitygroups_rpc.py
+++ b/neutron/tests/unit/agent/test_securitygroups_rpc.py
@@ -1111,6 +1111,7 @@ class BaseSecurityGroupAgentRpcTestCase(base.BaseTestCase):
     def setUp(self, defer_refresh_firewall=False):
         super(BaseSecurityGroupAgentRpcTestCase, self).setUp()
         set_firewall_driver(FIREWALL_NOOP_DRIVER)
+        ipv6._IS_IPV6_ENABLED = True
         self.agent = sg_rpc.SecurityGroupAgentRpc(
                 context=None, plugin_rpc=mock.Mock(),
                 defer_refresh_firewall=defer_refresh_firewall)


### PR DESCRIPTION
Fix management of in memory copy of iptables. Only manage ipv6 iptables if ipv6 enabled and use rule tagging to remove rules instead of doing a search of rule definitions. For a compute host with 450 ports these changes dropped processing time for deconstruction of iptables by 81% and overall iptables reconstruction by 70%.